### PR TITLE
URL 단축, 접속, 만료, 정보 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Environment File ###
 application-env.yml
+
+### Log File ###
+spy.log

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment File ###
+application-env.yml

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    implementation 'com.google.guava:guava:32.1.2-jre'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
 
     // Log
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // TestContainer
+    testImplementation 'org.testcontainers:mysql:1.19.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,3 +48,16 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+def profile = project.hasProperty("profile") ? project.property("profile").toString() : "dev"
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ["src/main/java"]
+        }
+        resources {
+            srcDirs = ["src/main/resources", "src/main/resources-${profile}"]
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+    // DB
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -36,6 +37,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // Log
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
     // TestContainer
     testImplementation 'org.testcontainers:mysql:1.19.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,36 +1,40 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.3'
-	id 'io.spring.dependency-management' version '1.1.3'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.3'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 group = 'kr.lnsc'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/http/AccessLink.http
+++ b/http/AccessLink.http
@@ -1,0 +1,2 @@
+GET http://localhost:8080/{{shortenPath}}
+Content-Type: application/json

--- a/http/CreateLink.http
+++ b/http/CreateLink.http
@@ -3,7 +3,7 @@
     client.global.set("EXPIRE_DATE", "2023-09-07")
 %}
 
-POST http://localhost:8080/api/v1/create
+POST http://localhost:8080/api/link/create
 Content-Type: application/json
 
 {

--- a/http/CreateLink.http
+++ b/http/CreateLink.http
@@ -1,0 +1,17 @@
+< {%
+    client.global.set("ORIGINAL_URL", "http://www.naver.com");
+    client.global.set("EXPIRE_DATE", "2023-09-07")
+%}
+
+POST http://localhost:8080/api/v1/create
+Content-Type: application/json
+
+{
+  "originalUrl": "{{ORIGINAL_URL}}",
+  "expireDate": "{{EXPIRE_DATE}}"
+}
+
+> {%
+    client.global.set("shortenPath", response.body.shortenUrl.split("/")[3]);
+    client.global.set("expireKey", response.body.expireKey);
+%}

--- a/http/ExpireLink.http
+++ b/http/ExpireLink.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/api/v1/expire
+POST http://localhost:8080/api/link/expire
 Content-Type: application/json
 
 {

--- a/http/ExpireLink.http
+++ b/http/ExpireLink.http
@@ -1,0 +1,7 @@
+POST http://localhost:8080/api/v1/expire
+Content-Type: application/json
+
+{
+  "shortenPath": "{{shortenPath}}",
+  "expireKey": "{{expireKey}}"
+}

--- a/http/GetLinkStat.http
+++ b/http/GetLinkStat.http
@@ -1,0 +1,2 @@
+GET http://localhost:8080/{{shortenPath}}/info
+Content-Type: application/json

--- a/http/GetLinkStat.http
+++ b/http/GetLinkStat.http
@@ -1,2 +1,2 @@
-GET http://localhost:8080/{{shortenPath}}/info
+GET http://localhost:8080/api/link/{{shortenPath}}
 Content-Type: application/json

--- a/src/main/java/kr/lnsc/api/config/JpaConfig.java
+++ b/src/main/java/kr/lnsc/api/config/JpaConfig.java
@@ -1,0 +1,7 @@
+package kr.lnsc.api.config;
+
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/kr/lnsc/api/config/JpaConfig.java
+++ b/src/main/java/kr/lnsc/api/config/JpaConfig.java
@@ -1,7 +1,9 @@
 package kr.lnsc.api.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@Configuration
 @EnableJpaAuditing
 public class JpaConfig {
 }

--- a/src/main/java/kr/lnsc/api/config/LinkConfig.java
+++ b/src/main/java/kr/lnsc/api/config/LinkConfig.java
@@ -1,0 +1,15 @@
+package kr.lnsc.api.config;
+
+import kr.lnsc.api.link.domain.generator.RandomShortenPathGenerator;
+import kr.lnsc.api.link.domain.generator.ShortenPathGenerator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LinkConfig {
+
+    @Bean
+    public ShortenPathGenerator shortenPathGenerator() {
+        return new RandomShortenPathGenerator();
+    }
+}

--- a/src/main/java/kr/lnsc/api/config/LinkConfig.java
+++ b/src/main/java/kr/lnsc/api/config/LinkConfig.java
@@ -1,7 +1,9 @@
 package kr.lnsc.api.config;
 
+import kr.lnsc.api.link.domain.generator.ExpireKeyGenerator;
 import kr.lnsc.api.link.domain.generator.RandomShortenPathGenerator;
 import kr.lnsc.api.link.domain.generator.ShortenPathGenerator;
+import kr.lnsc.api.link.domain.generator.UuidExpireKeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,5 +13,10 @@ public class LinkConfig {
     @Bean
     public ShortenPathGenerator shortenPathGenerator() {
         return new RandomShortenPathGenerator();
+    }
+
+    @Bean
+    public ExpireKeyGenerator expireKeyGenerator() {
+        return new UuidExpireKeyGenerator();
     }
 }

--- a/src/main/java/kr/lnsc/api/domain/link/Link.java
+++ b/src/main/java/kr/lnsc/api/domain/link/Link.java
@@ -1,0 +1,44 @@
+package kr.lnsc.api.domain.link;
+
+import jakarta.persistence.*;
+import kr.lnsc.api.model.TimeBaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Link extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "original_url"))
+    private Url originalUrl;
+
+    @Column(name = "shorten_Path", unique = true)
+    private String shortenPath;
+
+    @Column(name = "expired_key")
+    private String expiredKey;
+
+    @Column(name = "expired_at", columnDefinition = "datetime(6)")
+    private LocalDateTime expiredAt;
+
+    private Link(Long id, Url originalUrl, String shortenPath, String expiredKey, LocalDateTime expiredAt) {
+        this.id = id;
+        this.originalUrl = originalUrl;
+        this.shortenPath = shortenPath;
+        this.expiredKey = expiredKey;
+        this.expiredAt = expiredAt;
+    }
+
+    public static Link createLink(Url originalUrl, String shortenPath, String expiredKey, LocalDateTime expiredAt) {
+        return new Link(null, originalUrl, shortenPath, expiredKey, expiredAt);
+    }
+}

--- a/src/main/java/kr/lnsc/api/domain/link/Url.java
+++ b/src/main/java/kr/lnsc/api/domain/link/Url.java
@@ -1,0 +1,35 @@
+package kr.lnsc.api.domain.link;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import kr.lnsc.api.domain.link.exception.InvalidUrlException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.regex.Pattern;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Url {
+    private static final int URL_MAX_LENGTH = 2048;
+    private static final Pattern PATTERN = Pattern.compile("https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#()?&//=]*)");
+
+    @Column(length = URL_MAX_LENGTH)
+    private String value;
+
+    public Url(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(String value) {
+        if (!StringUtils.hasText(value) ||
+                value.length() > URL_MAX_LENGTH ||
+                !PATTERN.matcher(value).matches()) {
+            throw new InvalidUrlException();
+        }
+    }
+}

--- a/src/main/java/kr/lnsc/api/domain/link/exception/InvalidUrlException.java
+++ b/src/main/java/kr/lnsc/api/domain/link/exception/InvalidUrlException.java
@@ -1,0 +1,12 @@
+package kr.lnsc.api.domain.link.exception;
+
+import kr.lnsc.api.error.ErrorCode;
+import kr.lnsc.api.error.exception.InvalidValueException;
+
+public class InvalidUrlException extends InvalidValueException {
+    private static final String MESSAGE = "유효하지 않는 URL입니다. 확인 후 다시 입력해주세요.";
+
+    public InvalidUrlException() {
+        super(MESSAGE, ErrorCode.UNHANDLED_ERROR);
+    }
+}

--- a/src/main/java/kr/lnsc/api/error/ControllerAdvice.java
+++ b/src/main/java/kr/lnsc/api/error/ControllerAdvice.java
@@ -1,7 +1,12 @@
 package kr.lnsc.api.error;
 
+import kr.lnsc.api.error.exception.InvalidValueException;
+import kr.lnsc.api.error.exception.ResourceNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,6 +15,30 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ControllerAdvice {
     private static final String UNHANDLED_EXCEPTION_MESSAGE = "알 수 없는 오류가 발생했습니다. 관리자에게 연락해주세요.";
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ExceptionResponse handleMethodArgumentException(BindingResult bindingResult) {
+        String errorMessage = bindingResult.getFieldErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .toList()
+                .get(0);
+        return new ExceptionResponse(errorMessage, ErrorCode.INVALID_REQUEST_VALUE);
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ExceptionResponse handleResourceNotFoundException(ResourceNotFoundException e) {
+        log.error("handleResourceNotFoundException", e);
+        return ExceptionResponse.from(e);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(InvalidValueException.class)
+    public ExceptionResponse handleInvalidValueException(InvalidValueException e) {
+        log.error("handleInvalidValueException", e);
+        return ExceptionResponse.from(e);
+    }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)

--- a/src/main/java/kr/lnsc/api/error/ErrorCode.java
+++ b/src/main/java/kr/lnsc/api/error/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
 
     /* 400 */
     INVALID_URL("400-01"),
+    INVALID_REQUEST_VALUE("400-02"),
 
     /* 404 */
     LINK_NOT_FOUND("404-01"),

--- a/src/main/java/kr/lnsc/api/error/ErrorCode.java
+++ b/src/main/java/kr/lnsc/api/error/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     LINK_NOT_FOUND("404-01"),
 
     /* 500 */
-    UNHANDLED_ERROR("500-01");
+    UNHANDLED_ERROR("500-01"),
+    CAN_NOT_FOUND_UNIQUE_PATH("500-02");
 
     private final String value;
 

--- a/src/main/java/kr/lnsc/api/error/ErrorCode.java
+++ b/src/main/java/kr/lnsc/api/error/ErrorCode.java
@@ -4,6 +4,14 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
+
+    /* 400 */
+    INVALID_URL("400-01"),
+
+    /* 404 */
+    LINK_NOT_FOUND("404-01"),
+
+    /* 500 */
     UNHANDLED_ERROR("500-01");
 
     private final String value;

--- a/src/main/java/kr/lnsc/api/error/ExceptionResponse.java
+++ b/src/main/java/kr/lnsc/api/error/ExceptionResponse.java
@@ -1,6 +1,7 @@
 package kr.lnsc.api.error;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import kr.lnsc.api.error.exception.BusinessException;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +17,10 @@ public class ExceptionResponse {
     public ExceptionResponse(String message, ErrorCode code) {
         this.message = message;
         this.code = code;
+    }
+
+    public static ExceptionResponse from(BusinessException e) {
+        return new ExceptionResponse(e.getMessage(), e.getCode());
     }
 
     public LocalDateTime getTimestamp() {

--- a/src/main/java/kr/lnsc/api/error/ExceptionResponse.java
+++ b/src/main/java/kr/lnsc/api/error/ExceptionResponse.java
@@ -1,17 +1,21 @@
 package kr.lnsc.api.error;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.lnsc.api.error.exception.BusinessException;
 
 import java.time.LocalDateTime;
 
 public class ExceptionResponse {
 
-    @JsonFormat
+    @Schema(description = "서버 시간 기준 예외 발생 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime timestamp = LocalDateTime.now();
 
+    @Schema(description = "예외 메시지")
     private final String message;
 
+    @Schema(description = "에러 코드")
     private final ErrorCode code;
 
     public ExceptionResponse(String message, ErrorCode code) {

--- a/src/main/java/kr/lnsc/api/error/exception/InvalidValueException.java
+++ b/src/main/java/kr/lnsc/api/error/exception/InvalidValueException.java
@@ -1,0 +1,9 @@
+package kr.lnsc.api.error.exception;
+
+import kr.lnsc.api.error.ErrorCode;
+
+public abstract class InvalidValueException extends BusinessException {
+    public InvalidValueException(String message, ErrorCode code) {
+        super(message, code);
+    }
+}

--- a/src/main/java/kr/lnsc/api/error/exception/ResourceNotFoundException.java
+++ b/src/main/java/kr/lnsc/api/error/exception/ResourceNotFoundException.java
@@ -1,0 +1,9 @@
+package kr.lnsc.api.error.exception;
+
+import kr.lnsc.api.error.ErrorCode;
+
+public abstract class ResourceNotFoundException extends BusinessException {
+    public ResourceNotFoundException(String message, ErrorCode code) {
+        super(message, code);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/controller/LinkController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkController.java
@@ -1,0 +1,23 @@
+package kr.lnsc.api.link.controller;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.dto.response.CreateShortenLinkResponse;
+import kr.lnsc.api.link.service.LinkCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LinkController {
+    private final LinkCommand linkCommand;
+
+    @PostMapping("api/v1/create")
+    public CreateShortenLinkResponse createShortenLink(@Validated @RequestBody CreateShortenLinkRequest request) {
+        Link newLink = linkCommand.createLink(request);
+        return CreateShortenLinkResponse.from(newLink);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/controller/LinkController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.dto.request.ExpireShortenLinkRequest;
 import kr.lnsc.api.link.dto.response.CreateShortenLinkResponse;
 import kr.lnsc.api.link.dto.response.GetLinkStatInfoResponse;
 import kr.lnsc.api.link.service.LinkCommand;
@@ -34,6 +35,12 @@ public class LinkController {
     public CreateShortenLinkResponse createShortenLink(@Validated @RequestBody CreateShortenLinkRequest request) {
         Link newLink = linkCommand.createLink(request);
         return CreateShortenLinkResponse.from(newLink);
+    }
+
+    @Operation(summary = "단축 URL 임의 만료", description = "해당 단축 URL을 임의로 만료합니다.")
+    @PostMapping("api/v1/expire")
+    public void expireShortenLink(@Validated @RequestBody ExpireShortenLinkRequest request) {
+        linkCommand.expireLink(request);
     }
 
     @Operation(summary = "단축 URL 접속", description = "단축 URL로 접속하면 원래 URL로 리다이렉트됩니다.")

--- a/src/main/java/kr/lnsc/api/link/controller/LinkController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkController.java
@@ -1,5 +1,8 @@
 package kr.lnsc.api.link.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
 import kr.lnsc.api.link.dto.response.CreateShortenLinkResponse;
@@ -12,20 +15,25 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "link", description = "링크 API")
 @RestController
 @RequiredArgsConstructor
 public class LinkController {
     private final LinkCommand linkCommand;
     private final LinkHistoryCommand linkHistoryCommand;
 
+    @Operation(summary = "단축 URL 생성", description = "URL과 만료일자를 입력해 단축 URL을 생성합니다.")
     @PostMapping("api/v1/create")
     public CreateShortenLinkResponse createShortenLink(@Validated @RequestBody CreateShortenLinkRequest request) {
         Link newLink = linkCommand.createLink(request);
         return CreateShortenLinkResponse.from(newLink);
     }
 
+    @Operation(summary = "단축 URL 접속", description = "단축 URL로 접속하면 원래 URL로 리다이렉트됩니다.")
     @GetMapping("/{shortenPath}")
-    public ResponseEntity<?> redirectToOriginalUrl(@PathVariable String shortenPath) {
+    public ResponseEntity<?> redirectToOriginalUrl(
+            @Parameter(description = "단축 URL Path") @PathVariable String shortenPath
+    ) {
         Link findLink = linkHistoryCommand.accessLink(shortenPath);
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(findLink.originalUri());

--- a/src/main/java/kr/lnsc/api/link/controller/LinkController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkController.java
@@ -6,8 +6,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
 import kr.lnsc.api.link.dto.response.CreateShortenLinkResponse;
+import kr.lnsc.api.link.dto.response.GetLinkStatInfoResponse;
 import kr.lnsc.api.link.service.LinkCommand;
+import kr.lnsc.api.link.service.LinkQuery;
 import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
+import kr.lnsc.api.linkhistory.service.LinkHistoryQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -15,12 +18,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+
 @Tag(name = "link", description = "링크 API")
 @RestController
 @RequiredArgsConstructor
 public class LinkController {
     private final LinkCommand linkCommand;
+    private final LinkQuery linkQuery;
     private final LinkHistoryCommand linkHistoryCommand;
+    private final LinkHistoryQuery linkHistoryQuery;
 
     @Operation(summary = "단축 URL 생성", description = "URL과 만료일자를 입력해 단축 URL을 생성합니다.")
     @PostMapping("api/v1/create")
@@ -38,5 +45,16 @@ public class LinkController {
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(findLink.originalUri());
         return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
+    }
+
+    @Operation(summary = "단축 URL 통계 정보 조회", description = "해당 단축 URL의 통계 정보를 조회합니다.")
+    @GetMapping("/{shortenPath}/info")
+    public GetLinkStatInfoResponse getLinkStatisticalInformation(
+            @Parameter(description = "단축 URL Path") @PathVariable String shortenPath
+    ) {
+        Link findLink = linkQuery.getLink(shortenPath);
+        long dailyAccessCount = linkHistoryQuery.getAccessCount(findLink, LocalDate.now());
+        long totalAccessCount = linkHistoryQuery.getTotalAccessCount(findLink);
+        return GetLinkStatInfoResponse.of(findLink, dailyAccessCount, totalAccessCount);
     }
 }

--- a/src/main/java/kr/lnsc/api/link/controller/LinkController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkController.java
@@ -4,64 +4,25 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.lnsc.api.link.domain.Link;
-import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
-import kr.lnsc.api.link.dto.request.ExpireShortenLinkRequest;
-import kr.lnsc.api.link.dto.response.CreateShortenLinkResponse;
-import kr.lnsc.api.link.dto.response.GetLinkStatInfoResponse;
-import kr.lnsc.api.link.service.LinkCommand;
-import kr.lnsc.api.link.service.LinkQuery;
 import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
-import kr.lnsc.api.linkhistory.service.LinkHistoryQuery;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.servlet.view.RedirectView;
 
-import java.time.LocalDate;
-
-@Tag(name = "link", description = "링크 API")
-@RestController
+@Tag(name = "link API", description = "링크 API")
+@Controller
 @RequiredArgsConstructor
 public class LinkController {
-    private final LinkCommand linkCommand;
-    private final LinkQuery linkQuery;
     private final LinkHistoryCommand linkHistoryCommand;
-    private final LinkHistoryQuery linkHistoryQuery;
-
-    @Operation(summary = "단축 URL 생성", description = "URL과 만료일자를 입력해 단축 URL을 생성합니다.")
-    @PostMapping("api/v1/create")
-    public CreateShortenLinkResponse createShortenLink(@Validated @RequestBody CreateShortenLinkRequest request) {
-        Link newLink = linkCommand.createLink(request);
-        return CreateShortenLinkResponse.from(newLink);
-    }
-
-    @Operation(summary = "단축 URL 임의 만료", description = "해당 단축 URL을 임의로 만료합니다.")
-    @PostMapping("api/v1/expire")
-    public void expireShortenLink(@Validated @RequestBody ExpireShortenLinkRequest request) {
-        linkCommand.expireLink(request);
-    }
 
     @Operation(summary = "단축 URL 접속", description = "단축 URL로 접속하면 원래 URL로 리다이렉트됩니다.")
     @GetMapping("/{shortenPath}")
-    public ResponseEntity<?> redirectToOriginalUrl(
+    public RedirectView redirectToOriginalUrl(
             @Parameter(description = "단축 URL Path") @PathVariable String shortenPath
     ) {
         Link findLink = linkHistoryCommand.accessLink(shortenPath);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(findLink.originalUri());
-        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
-    }
-
-    @Operation(summary = "단축 URL 통계 정보 조회", description = "해당 단축 URL의 통계 정보를 조회합니다.")
-    @GetMapping("/{shortenPath}/info")
-    public GetLinkStatInfoResponse getLinkStatisticalInformation(
-            @Parameter(description = "단축 URL Path") @PathVariable String shortenPath
-    ) {
-        Link findLink = linkQuery.getLink(shortenPath);
-        long dailyAccessCount = linkHistoryQuery.getAccessCount(findLink, LocalDate.now());
-        long totalAccessCount = linkHistoryQuery.getTotalAccessCount(findLink);
-        return GetLinkStatInfoResponse.of(findLink, dailyAccessCount, totalAccessCount);
+        return new RedirectView(findLink.getOriginalUrl().getValue());
     }
 }

--- a/src/main/java/kr/lnsc/api/link/controller/LinkController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkController.java
@@ -4,20 +4,31 @@ import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
 import kr.lnsc.api.link.dto.response.CreateShortenLinkResponse;
 import kr.lnsc.api.link.service.LinkCommand;
+import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class LinkController {
     private final LinkCommand linkCommand;
+    private final LinkHistoryCommand linkHistoryCommand;
 
     @PostMapping("api/v1/create")
     public CreateShortenLinkResponse createShortenLink(@Validated @RequestBody CreateShortenLinkRequest request) {
         Link newLink = linkCommand.createLink(request);
         return CreateShortenLinkResponse.from(newLink);
+    }
+
+    @GetMapping("/{shortenPath}")
+    public ResponseEntity<?> redirectToOriginalUrl(@PathVariable String shortenPath) {
+        Link findLink = linkHistoryCommand.accessLink(shortenPath);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(findLink.originalUri());
+        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
     }
 }

--- a/src/main/java/kr/lnsc/api/link/controller/LinkRestController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkRestController.java
@@ -26,20 +26,20 @@ public class LinkRestController {
     private final LinkHistoryQuery linkHistoryQuery;
 
     @Operation(summary = "단축 URL 생성", description = "URL과 만료일자를 입력해 단축 URL을 생성합니다.")
-    @PostMapping("api/v1/create")
+    @PostMapping("/api/link/create")
     public CreateShortenLinkResponse createShortenLink(@Validated @RequestBody CreateShortenLinkRequest request) {
         Link newLink = linkCommand.createLink(request);
         return CreateShortenLinkResponse.from(newLink);
     }
 
     @Operation(summary = "단축 URL 임의 만료", description = "해당 단축 URL을 임의로 만료합니다.")
-    @PostMapping("api/v1/expire")
+    @PostMapping("/api/link/expire")
     public void expireShortenLink(@Validated @RequestBody ExpireShortenLinkRequest request) {
         linkCommand.expireLink(request);
     }
 
     @Operation(summary = "단축 URL 통계 정보 조회", description = "해당 단축 URL의 통계 정보를 조회합니다.")
-    @GetMapping("/{shortenPath}/info")
+    @GetMapping("/api/link/{shortenPath}")
     public GetLinkStatInfoResponse getLinkStatisticalInformation(
             @Parameter(description = "단축 URL Path") @PathVariable String shortenPath
     ) {

--- a/src/main/java/kr/lnsc/api/link/controller/LinkRestController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkRestController.java
@@ -1,0 +1,51 @@
+package kr.lnsc.api.link.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.dto.request.ExpireShortenLinkRequest;
+import kr.lnsc.api.link.dto.response.CreateShortenLinkResponse;
+import kr.lnsc.api.link.dto.response.GetLinkStatInfoResponse;
+import kr.lnsc.api.link.service.LinkCommand;
+import kr.lnsc.api.link.service.LinkQuery;
+import kr.lnsc.api.linkhistory.service.LinkHistoryQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@Tag(name = "link REST API", description = "링크 REST API")
+@RestController
+@RequiredArgsConstructor
+public class LinkRestController {
+    private final LinkCommand linkCommand;
+    private final LinkQuery linkQuery;
+    private final LinkHistoryQuery linkHistoryQuery;
+
+    @Operation(summary = "단축 URL 생성", description = "URL과 만료일자를 입력해 단축 URL을 생성합니다.")
+    @PostMapping("api/v1/create")
+    public CreateShortenLinkResponse createShortenLink(@Validated @RequestBody CreateShortenLinkRequest request) {
+        Link newLink = linkCommand.createLink(request);
+        return CreateShortenLinkResponse.from(newLink);
+    }
+
+    @Operation(summary = "단축 URL 임의 만료", description = "해당 단축 URL을 임의로 만료합니다.")
+    @PostMapping("api/v1/expire")
+    public void expireShortenLink(@Validated @RequestBody ExpireShortenLinkRequest request) {
+        linkCommand.expireLink(request);
+    }
+
+    @Operation(summary = "단축 URL 통계 정보 조회", description = "해당 단축 URL의 통계 정보를 조회합니다.")
+    @GetMapping("/{shortenPath}/info")
+    public GetLinkStatInfoResponse getLinkStatisticalInformation(
+            @Parameter(description = "단축 URL Path") @PathVariable String shortenPath
+    ) {
+        Link findLink = linkQuery.getLink(shortenPath);
+        long dailyAccessCount = linkHistoryQuery.getAccessCount(findLink, LocalDate.now());
+        long totalAccessCount = linkHistoryQuery.getTotalAccessCount(findLink);
+        return GetLinkStatInfoResponse.of(findLink, dailyAccessCount, totalAccessCount);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/domain/Link.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Link.java
@@ -27,22 +27,22 @@ public class Link extends TimeBaseEntity {
     @Column(name = "shorten_Path", unique = true)
     private String shortenPath;
 
-    @Column(name = "expired_key")
-    private String expiredKey;
+    @Column(name = "expire_key")
+    private String expireKey;
 
     @Column(name = "expired_at", columnDefinition = "datetime(6)")
     private LocalDateTime expiredAt;
 
-    private Link(Long id, Url originalUrl, String shortenPath, String expiredKey, LocalDateTime expiredAt) {
+    private Link(Long id, Url originalUrl, String shortenPath, String expireKey, LocalDateTime expiredAt) {
         this.id = id;
         this.originalUrl = originalUrl;
         this.shortenPath = shortenPath;
-        this.expiredKey = expiredKey;
+        this.expireKey = expireKey;
         this.expiredAt = expiredAt;
     }
 
-    public static Link createLink(Url originalUrl, String shortenPath, String expiredKey, LocalDate expireDate) {
-        return new Link(null, originalUrl, shortenPath, expiredKey, toExpiredAt(expireDate));
+    public static Link createLink(Url originalUrl, String shortenPath, String expireKey, LocalDate expireDate) {
+        return new Link(null, originalUrl, shortenPath, expireKey, toExpiredAt(expireDate));
     }
 
     public String shortenUrl() {

--- a/src/main/java/kr/lnsc/api/link/domain/Link.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Link.java
@@ -21,10 +21,10 @@ public class Link extends TimeBaseEntity {
     private Long id;
 
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "original_url"))
+    @AttributeOverride(name = "value", column = @Column(name = "original_url", length = Url.URL_MAX_LENGTH))
     private Url originalUrl;
 
-    @Column(name = "shorten_Path", unique = true)
+    @Column(name = "shorten_path", unique = true)
     private String shortenPath;
 
     @Column(name = "expire_key")

--- a/src/main/java/kr/lnsc/api/link/domain/Link.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Link.java
@@ -50,6 +50,6 @@ public class Link extends TimeBaseEntity {
     }
 
     private static LocalDateTime toExpiredAt(LocalDate expireDate) {
-        return LocalDateTime.of(expireDate, LocalTime.MAX);
+        return LocalDateTime.of(expireDate.plusDays(1), LocalTime.MIN);
     }
 }

--- a/src/main/java/kr/lnsc/api/link/domain/Link.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Link.java
@@ -1,4 +1,4 @@
-package kr.lnsc.api.domain.link;
+package kr.lnsc.api.link.domain;
 
 import jakarta.persistence.*;
 import kr.lnsc.api.model.TimeBaseEntity;

--- a/src/main/java/kr/lnsc/api/link/domain/Link.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Link.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.net.URI;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -47,6 +48,10 @@ public class Link extends TimeBaseEntity {
 
     public String shortenUrl() {
         return String.format("%s/%s", BaseUrlProperty.getBaseUrl(), this.shortenPath);
+    }
+
+    public URI originalUri() {
+        return URI.create(originalUrl.getValue());
     }
 
     private static LocalDateTime toExpiredAt(LocalDate expireDate) {

--- a/src/main/java/kr/lnsc/api/link/domain/Link.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Link.java
@@ -2,11 +2,14 @@ package kr.lnsc.api.link.domain;
 
 import jakarta.persistence.*;
 import kr.lnsc.api.model.TimeBaseEntity;
+import kr.lnsc.api.property.BaseUrlProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -38,7 +41,15 @@ public class Link extends TimeBaseEntity {
         this.expiredAt = expiredAt;
     }
 
-    public static Link createLink(Url originalUrl, String shortenPath, String expiredKey, LocalDateTime expiredAt) {
-        return new Link(null, originalUrl, shortenPath, expiredKey, expiredAt);
+    public static Link createLink(Url originalUrl, String shortenPath, String expiredKey, LocalDate expireDate) {
+        return new Link(null, originalUrl, shortenPath, expiredKey, toExpiredAt(expireDate));
+    }
+
+    public String shortenUrl() {
+        return String.format("%s/%s", BaseUrlProperty.getBaseUrl(), this.shortenPath);
+    }
+
+    private static LocalDateTime toExpiredAt(LocalDate expireDate) {
+        return LocalDateTime.of(expireDate, LocalTime.MAX);
     }
 }

--- a/src/main/java/kr/lnsc/api/link/domain/Link.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Link.java
@@ -54,6 +54,10 @@ public class Link extends TimeBaseEntity {
         return URI.create(originalUrl.getValue());
     }
 
+    public boolean isSameExpireKey(String expireKey) {
+        return this.expireKey.equals(expireKey);
+    }
+
     private static LocalDateTime toExpiredAt(LocalDate expireDate) {
         return LocalDateTime.of(expireDate.plusDays(1), LocalTime.MIN);
     }

--- a/src/main/java/kr/lnsc/api/link/domain/Url.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Url.java
@@ -15,10 +15,10 @@ import java.util.regex.Pattern;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Url {
-    private static final int URL_MAX_LENGTH = 2048;
+    public static final int URL_MAX_LENGTH = 2048;
     private static final Pattern PATTERN = Pattern.compile("https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#()?&//=]*)");
 
-    @Column(length = URL_MAX_LENGTH)
+    @Column(name = "url", length = URL_MAX_LENGTH)
     private String value;
 
     public Url(String value) {

--- a/src/main/java/kr/lnsc/api/link/domain/Url.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Url.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 @Embeddable
@@ -31,5 +32,18 @@ public class Url {
                 !PATTERN.matcher(value).matches()) {
             throw new InvalidUrlException();
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Url url = (Url) o;
+        return Objects.equals(getValue(), url.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
     }
 }

--- a/src/main/java/kr/lnsc/api/link/domain/Url.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Url.java
@@ -1,8 +1,8 @@
-package kr.lnsc.api.domain.link;
+package kr.lnsc.api.link.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import kr.lnsc.api.domain.link.exception.InvalidUrlException;
+import kr.lnsc.api.link.exception.InvalidUrlException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/kr/lnsc/api/link/domain/generator/ExpireKeyGenerator.java
+++ b/src/main/java/kr/lnsc/api/link/domain/generator/ExpireKeyGenerator.java
@@ -1,0 +1,6 @@
+package kr.lnsc.api.link.domain.generator;
+
+@FunctionalInterface
+public interface ExpireKeyGenerator {
+    String generate();
+}

--- a/src/main/java/kr/lnsc/api/link/domain/generator/RandomShortenPathGenerator.java
+++ b/src/main/java/kr/lnsc/api/link/domain/generator/RandomShortenPathGenerator.java
@@ -1,0 +1,31 @@
+package kr.lnsc.api.link.domain.generator;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RandomShortenPathGenerator implements ShortenPathGenerator {
+    private static final int PATH_LENGTH = 7;
+    private static final List<Character> AVAILABLE_CHARACTERS = initializedAvailableCharacters();
+
+    @Override
+    public String generate() {
+        StringBuilder sb = new StringBuilder();
+        for (int count = 0; count < PATH_LENGTH; count++) {
+            int randomNumber = (int) (Math.random() * AVAILABLE_CHARACTERS.size());
+            sb.append(AVAILABLE_CHARACTERS.get(randomNumber));
+        }
+        return sb.toString();
+    }
+
+    private static List<Character> initializedAvailableCharacters() {
+        Set<Character> result = new HashSet<>();
+        for (int ch = 'a'; ch <= 'z'; ch++) {
+            result.add((char) ch);
+        }
+        for (int ch = 'A'; ch <= 'Z'; ch++) {
+            result.add((char) ch);
+        }
+        return List.copyOf(result);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/domain/generator/ShortenPathGenerator.java
+++ b/src/main/java/kr/lnsc/api/link/domain/generator/ShortenPathGenerator.java
@@ -1,0 +1,6 @@
+package kr.lnsc.api.link.domain.generator;
+
+@FunctionalInterface
+public interface ShortenPathGenerator {
+    String generate();
+}

--- a/src/main/java/kr/lnsc/api/link/domain/generator/UuidExpireKeyGenerator.java
+++ b/src/main/java/kr/lnsc/api/link/domain/generator/UuidExpireKeyGenerator.java
@@ -1,0 +1,12 @@
+package kr.lnsc.api.link.domain.generator;
+
+import java.util.UUID;
+
+public class UuidExpireKeyGenerator implements ExpireKeyGenerator {
+    private static final int EXPIRE_KEY_LENGTH = 8;
+
+    @Override
+    public String generate() {
+        return UUID.randomUUID().toString().substring(0, EXPIRE_KEY_LENGTH);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
+++ b/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
@@ -1,5 +1,6 @@
 package kr.lnsc.api.link.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import kr.lnsc.api.link.domain.Url;
 import kr.lnsc.api.link.validator.ExpireTime;
@@ -12,9 +13,11 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class CreateShortenLinkRequest {
 
+    @Schema(description = "단축할 원본 URL")
     @NotNull(message = "단축할 URL 주소를 입력해주세요.")
     private Url originalUrl;
 
+    @Schema(description = "단축 URL 만료일자")
     @ExpireTime
     private LocalDate expireDate;
 

--- a/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
+++ b/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
@@ -15,7 +15,6 @@ public class CreateShortenLinkRequest {
     @NotNull(message = "단축할 URL 주소를 입력해주세요.")
     private Url originalUrl;
 
-    @NotNull(message = "만료일자를 입력해주세요.")
     @ExpireTime
     private LocalDate expireDate;
 

--- a/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
+++ b/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
@@ -4,12 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import kr.lnsc.api.link.domain.Url;
 import kr.lnsc.api.link.validator.ExpireTime;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@Getter
 @NoArgsConstructor
 public class CreateShortenLinkRequest {
 
@@ -24,5 +22,13 @@ public class CreateShortenLinkRequest {
     public CreateShortenLinkRequest(Url originalUrl, LocalDate expireDate) {
         this.originalUrl = originalUrl;
         this.expireDate = expireDate;
+    }
+
+    public String getOriginalUrl() {
+        return originalUrl.getValue();
+    }
+
+    public LocalDate getExpireDate() {
+        return expireDate;
     }
 }

--- a/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
+++ b/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
@@ -1,0 +1,26 @@
+package kr.lnsc.api.link.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import kr.lnsc.api.link.domain.Url;
+import kr.lnsc.api.link.validator.ExpireTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class CreateShortenLinkRequest {
+
+    @NotNull(message = "단축할 URL 주소를 입력해주세요.")
+    private Url originalUrl;
+
+    @NotNull(message = "만료일자를 입력해주세요.")
+    @ExpireTime
+    private LocalDate expireDate;
+
+    public CreateShortenLinkRequest(Url originalUrl, LocalDate expireDate) {
+        this.originalUrl = originalUrl;
+        this.expireDate = expireDate;
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/dto/request/ExpireShortenLinkRequest.java
+++ b/src/main/java/kr/lnsc/api/link/dto/request/ExpireShortenLinkRequest.java
@@ -1,0 +1,24 @@
+package kr.lnsc.api.link.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ExpireShortenLinkRequest {
+
+    @Schema(description = "단축 URL의 Path")
+    @NotBlank(message = "단축 URL의 Path를 입력해주세요.")
+    private String shortenPath;
+
+    @Schema(description = "단축 URL 만료키")
+    @NotBlank(message = "만료키를 입력해주세요.")
+    private String expireKey;
+
+    public ExpireShortenLinkRequest(String shortenPath, String expireKey) {
+        this.shortenPath = shortenPath;
+        this.expireKey = expireKey;
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/dto/response/CreateShortenLinkResponse.java
+++ b/src/main/java/kr/lnsc/api/link/dto/response/CreateShortenLinkResponse.java
@@ -1,0 +1,21 @@
+package kr.lnsc.api.link.dto.response;
+
+import kr.lnsc.api.link.domain.Link;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CreateShortenLinkResponse {
+    private String shortenUrl;
+    private LocalDateTime expiredAt;
+
+    public CreateShortenLinkResponse(String shortenUrl, LocalDateTime expiredAt) {
+        this.shortenUrl = shortenUrl;
+        this.expiredAt = expiredAt;
+    }
+
+    public static CreateShortenLinkResponse of(Link link) {
+        return new CreateShortenLinkResponse(link.shortenUrl(), link.getExpiredAt());
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/dto/response/CreateShortenLinkResponse.java
+++ b/src/main/java/kr/lnsc/api/link/dto/response/CreateShortenLinkResponse.java
@@ -9,13 +9,15 @@ import java.time.LocalDateTime;
 public class CreateShortenLinkResponse {
     private String shortenUrl;
     private LocalDateTime expiredAt;
+    private String expireKey;
 
-    public CreateShortenLinkResponse(String shortenUrl, LocalDateTime expiredAt) {
+    public CreateShortenLinkResponse(String shortenUrl, LocalDateTime expiredAt, String expireKey) {
         this.shortenUrl = shortenUrl;
         this.expiredAt = expiredAt;
+        this.expireKey = expireKey;
     }
 
     public static CreateShortenLinkResponse from(Link link) {
-        return new CreateShortenLinkResponse(link.shortenUrl(), link.getExpiredAt());
+        return new CreateShortenLinkResponse(link.shortenUrl(), link.getExpiredAt(), link.getExpireKey());
     }
 }

--- a/src/main/java/kr/lnsc/api/link/dto/response/CreateShortenLinkResponse.java
+++ b/src/main/java/kr/lnsc/api/link/dto/response/CreateShortenLinkResponse.java
@@ -15,7 +15,7 @@ public class CreateShortenLinkResponse {
         this.expiredAt = expiredAt;
     }
 
-    public static CreateShortenLinkResponse of(Link link) {
+    public static CreateShortenLinkResponse from(Link link) {
         return new CreateShortenLinkResponse(link.shortenUrl(), link.getExpiredAt());
     }
 }

--- a/src/main/java/kr/lnsc/api/link/dto/response/CreateShortenLinkResponse.java
+++ b/src/main/java/kr/lnsc/api/link/dto/response/CreateShortenLinkResponse.java
@@ -1,5 +1,6 @@
 package kr.lnsc.api.link.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.lnsc.api.link.domain.Link;
 import lombok.Getter;
 
@@ -7,8 +8,14 @@ import java.time.LocalDateTime;
 
 @Getter
 public class CreateShortenLinkResponse {
+
+    @Schema(description = "단축된 URL")
     private String shortenUrl;
+
+    @Schema(description = "단축 URL 만료일자")
     private LocalDateTime expiredAt;
+
+    @Schema(description = "단축 URL 만료키")
     private String expireKey;
 
     public CreateShortenLinkResponse(String shortenUrl, LocalDateTime expiredAt, String expireKey) {

--- a/src/main/java/kr/lnsc/api/link/dto/response/GetLinkStatInfoResponse.java
+++ b/src/main/java/kr/lnsc/api/link/dto/response/GetLinkStatInfoResponse.java
@@ -1,0 +1,44 @@
+package kr.lnsc.api.link.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.lnsc.api.link.domain.Link;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GetLinkStatInfoResponse {
+
+    @Schema(description = "원본 URL")
+    private String originalUrl;
+
+    @Schema(description = "오늘 접속 횟수")
+    private long dailyAccessCount;
+
+    @Schema(description = "누적 접속 횟수")
+    private long totalAccessCount;
+
+    @Schema(description = "단축 URL 만료일자")
+    private LocalDateTime expiredAt;
+
+    @Schema(description = "단축 URL 생성일자")
+    private LocalDateTime createdAt;
+
+    private GetLinkStatInfoResponse(String originalUrl, long dailyAccessCount, long totalAccessCount, LocalDateTime expiredAt, LocalDateTime createdAt) {
+        this.originalUrl = originalUrl;
+        this.dailyAccessCount = dailyAccessCount;
+        this.totalAccessCount = totalAccessCount;
+        this.expiredAt = expiredAt;
+        this.createdAt = createdAt;
+    }
+
+    public static GetLinkStatInfoResponse of(Link link, long dailyAccessCount, long totalAccessCount) {
+        return new GetLinkStatInfoResponse(
+                link.getOriginalUrl().getValue(),
+                dailyAccessCount,
+                totalAccessCount,
+                link.getExpiredAt(),
+                link.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/exception/CanNotFoundUniquePathException.java
+++ b/src/main/java/kr/lnsc/api/link/exception/CanNotFoundUniquePathException.java
@@ -1,0 +1,12 @@
+package kr.lnsc.api.link.exception;
+
+import kr.lnsc.api.error.ErrorCode;
+import kr.lnsc.api.error.exception.BusinessException;
+
+public class CanNotFoundUniquePathException extends BusinessException {
+    private static final String MESSAGE = "생성 가능한 단축 URL 탐색에 실패했습니다. 다시 시도해주세요.";
+
+    public CanNotFoundUniquePathException() {
+        super(MESSAGE, ErrorCode.CAN_NOT_FOUND_UNIQUE_PATH);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/exception/InvalidExpireKeyException.java
+++ b/src/main/java/kr/lnsc/api/link/exception/InvalidExpireKeyException.java
@@ -1,0 +1,12 @@
+package kr.lnsc.api.link.exception;
+
+import kr.lnsc.api.error.ErrorCode;
+import kr.lnsc.api.error.exception.InvalidValueException;
+
+public class InvalidExpireKeyException extends InvalidValueException {
+    private static final String MESSAGE = "만료키가 일치하지 않거나 유효하지 않는 만료키입니다. 확인 후 다시 입력해주세요.";
+
+    public InvalidExpireKeyException() {
+        super(MESSAGE, ErrorCode.INVALID_REQUEST_VALUE);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/exception/InvalidUrlException.java
+++ b/src/main/java/kr/lnsc/api/link/exception/InvalidUrlException.java
@@ -1,4 +1,4 @@
-package kr.lnsc.api.domain.link.exception;
+package kr.lnsc.api.link.exception;
 
 import kr.lnsc.api.error.ErrorCode;
 import kr.lnsc.api.error.exception.InvalidValueException;
@@ -7,6 +7,6 @@ public class InvalidUrlException extends InvalidValueException {
     private static final String MESSAGE = "유효하지 않는 URL입니다. 확인 후 다시 입력해주세요.";
 
     public InvalidUrlException() {
-        super(MESSAGE, ErrorCode.UNHANDLED_ERROR);
+        super(MESSAGE, ErrorCode.INVALID_URL);
     }
 }

--- a/src/main/java/kr/lnsc/api/link/exception/LinkNotFoundException.java
+++ b/src/main/java/kr/lnsc/api/link/exception/LinkNotFoundException.java
@@ -1,0 +1,12 @@
+package kr.lnsc.api.link.exception;
+
+import kr.lnsc.api.error.ErrorCode;
+import kr.lnsc.api.error.exception.ResourceNotFoundException;
+
+public class LinkNotFoundException extends ResourceNotFoundException {
+    private static final String MESSAGE = "해당 링크가 존재하지 않아 불러올 수 없습니다.";
+
+    public LinkNotFoundException() {
+        super(MESSAGE, ErrorCode.LINK_NOT_FOUND);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/exception/LinkNotFoundException.java
+++ b/src/main/java/kr/lnsc/api/link/exception/LinkNotFoundException.java
@@ -4,7 +4,7 @@ import kr.lnsc.api.error.ErrorCode;
 import kr.lnsc.api.error.exception.ResourceNotFoundException;
 
 public class LinkNotFoundException extends ResourceNotFoundException {
-    private static final String MESSAGE = "해당 링크가 존재하지 않아 불러올 수 없습니다.";
+    private static final String MESSAGE = "해당 링크가 이미 만료되었거나 존재하지 않아 불러올 수 없습니다.";
 
     public LinkNotFoundException() {
         super(MESSAGE, ErrorCode.LINK_NOT_FOUND);

--- a/src/main/java/kr/lnsc/api/link/repository/LinkRepository.java
+++ b/src/main/java/kr/lnsc/api/link/repository/LinkRepository.java
@@ -2,12 +2,14 @@ package kr.lnsc.api.link.repository;
 
 import kr.lnsc.api.link.domain.Link;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface LinkRepository extends JpaRepository<Link, Long> {
 
-    Optional<Link> findByShortenPath(String shortenPath);
+    @Query("SELECT l FROM Link l WHERE l.shortenPath = :shortenPath AND l.expiredAt > now()")
+    Optional<Link> findLink(String shortenPath);
 
     boolean existsByShortenPath(String shortenPath);
 }

--- a/src/main/java/kr/lnsc/api/link/repository/LinkRepository.java
+++ b/src/main/java/kr/lnsc/api/link/repository/LinkRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface LinkRepository extends JpaRepository<Link, Long> {
 
     Optional<Link> findByShortenPath(String shortenPath);
+
+    boolean existsByShortenPath(String shortenPath);
 }

--- a/src/main/java/kr/lnsc/api/link/repository/LinkRepository.java
+++ b/src/main/java/kr/lnsc/api/link/repository/LinkRepository.java
@@ -1,0 +1,11 @@
+package kr.lnsc.api.link.repository;
+
+import kr.lnsc.api.link.domain.Link;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LinkRepository extends JpaRepository<Link, Long> {
+
+    Optional<Link> findByShortenPath(String shortenPath);
+}

--- a/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
+++ b/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
@@ -1,0 +1,47 @@
+package kr.lnsc.api.link.service;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.domain.generator.ExpireKeyGenerator;
+import kr.lnsc.api.link.domain.generator.ShortenPathGenerator;
+import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.exception.CanNotFoundUniquePathException;
+import kr.lnsc.api.link.repository.LinkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class LinkCommand {
+    private static final int ATTEMPT_LIMIT = 30;
+
+    private final LinkRepository linkRepository;
+    private final ShortenPathGenerator shortenPathGenerator;
+    private final ExpireKeyGenerator expireKeyGenerator;
+
+    public Link createLink(CreateShortenLinkRequest request) {
+        String shortenPath = getUniqueShortenPath();
+        String expireKey = expireKeyGenerator.generate();
+
+        Link createdLink = Link.createLink(
+                request.getOriginalUrl(),
+                shortenPath,
+                expireKey,
+                request.getExpireDate()
+        );
+        return linkRepository.save(createdLink);
+    }
+
+    private String getUniqueShortenPath() {
+        int attempt = 0;
+        while (attempt < ATTEMPT_LIMIT) {
+            String generatedShortenPath = shortenPathGenerator.generate();
+            if (!linkRepository.existsByShortenPath(generatedShortenPath)) {
+                return generatedShortenPath;
+            }
+            attempt++;
+        }
+        throw new CanNotFoundUniquePathException();
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
+++ b/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
@@ -4,8 +4,11 @@ import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.domain.generator.ExpireKeyGenerator;
 import kr.lnsc.api.link.domain.generator.ShortenPathGenerator;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.dto.request.ExpireShortenLinkRequest;
 import kr.lnsc.api.link.exception.CanNotFoundUniquePathException;
+import kr.lnsc.api.link.exception.InvalidExpireKeyException;
 import kr.lnsc.api.link.repository.LinkRepository;
+import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +23,9 @@ public class LinkCommand {
     private final ShortenPathGenerator shortenPathGenerator;
     private final ExpireKeyGenerator expireKeyGenerator;
 
+    private final LinkQuery linkQuery;
+    private final LinkHistoryCommand linkHistoryCommand;
+
     public Link createLink(CreateShortenLinkRequest request) {
         String shortenPath = getUniqueShortenPath();
         String expireKey = expireKeyGenerator.generate();
@@ -31,6 +37,16 @@ public class LinkCommand {
                 request.getExpireDate()
         );
         return linkRepository.save(createdLink);
+    }
+
+    public void expireLink(ExpireShortenLinkRequest request) {
+        Link findLink = linkQuery.getLink(request.getShortenPath());
+
+        if (!findLink.isSameExpireKey(request.getExpireKey())) {
+            throw new InvalidExpireKeyException();
+        }
+        linkHistoryCommand.removeAllLinkHistory(findLink);
+        linkRepository.deleteById(findLink.getId());
     }
 
     private String getUniqueShortenPath() {

--- a/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
+++ b/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
@@ -1,6 +1,7 @@
 package kr.lnsc.api.link.service;
 
 import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.domain.Url;
 import kr.lnsc.api.link.domain.generator.ExpireKeyGenerator;
 import kr.lnsc.api.link.domain.generator.ShortenPathGenerator;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
@@ -31,7 +32,7 @@ public class LinkCommand {
         String expireKey = expireKeyGenerator.generate();
 
         Link createdLink = Link.createLink(
-                request.getOriginalUrl(),
+                new Url(request.getOriginalUrl()),
                 shortenPath,
                 expireKey,
                 request.getExpireDate()

--- a/src/main/java/kr/lnsc/api/link/service/LinkQuery.java
+++ b/src/main/java/kr/lnsc/api/link/service/LinkQuery.java
@@ -1,6 +1,5 @@
 package kr.lnsc.api.link.service;
 
-
 import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.exception.LinkNotFoundException;
 import kr.lnsc.api.link.repository.LinkRepository;
@@ -12,11 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class LinkQuery {
-
     private final LinkRepository linkRepository;
 
     public Link getLink(String shortenPath) {
-        return linkRepository.findByShortenPath(shortenPath)
+        return linkRepository.findLink(shortenPath)
                 .orElseThrow(LinkNotFoundException::new);
     }
 }

--- a/src/main/java/kr/lnsc/api/link/service/LinkQuery.java
+++ b/src/main/java/kr/lnsc/api/link/service/LinkQuery.java
@@ -1,0 +1,22 @@
+package kr.lnsc.api.link.service;
+
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.exception.LinkNotFoundException;
+import kr.lnsc.api.link.repository.LinkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class LinkQuery {
+
+    private final LinkRepository linkRepository;
+
+    public Link getLink(String shortenPath) {
+        return linkRepository.findByShortenPath(shortenPath)
+                .orElseThrow(LinkNotFoundException::new);
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/validator/ExpireTime.java
+++ b/src/main/java/kr/lnsc/api/link/validator/ExpireTime.java
@@ -1,0 +1,20 @@
+package kr.lnsc.api.link.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = ExpireTimeValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ExpireTime {
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kr/lnsc/api/link/validator/ExpireTimeValidator.java
+++ b/src/main/java/kr/lnsc/api/link/validator/ExpireTimeValidator.java
@@ -1,0 +1,27 @@
+package kr.lnsc.api.link.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+
+public class ExpireTimeValidator implements ConstraintValidator<ExpireTime, LocalDate> {
+    private static final String MESSAGE = "만료일자는 오늘보다 이전 날일 수 없습니다. 확인 후 다시 입력해주세요.";
+
+    @Override
+    public boolean isValid(LocalDate value, ConstraintValidatorContext context) {
+        LocalDate today = LocalDate.now();
+
+        if (today.isAfter(value)) {
+            addConstraintViolation(context, MESSAGE);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void addConstraintViolation(ConstraintValidatorContext context, String message) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/validator/ExpireTimeValidator.java
+++ b/src/main/java/kr/lnsc/api/link/validator/ExpireTimeValidator.java
@@ -6,14 +6,19 @@ import jakarta.validation.ConstraintValidatorContext;
 import java.time.LocalDate;
 
 public class ExpireTimeValidator implements ConstraintValidator<ExpireTime, LocalDate> {
-    private static final String MESSAGE = "만료일자는 오늘보다 이전 날일 수 없습니다. 확인 후 다시 입력해주세요.";
+    private static final String NULL_ERROR_MESSAGE = "만료일자를 입력해주세요.";
+    private static final String INVALID_EXPIRE_DATE_MESSAGE = "만료일자는 오늘보다 이전 날일 수 없습니다. 확인 후 다시 입력해주세요.";
 
     @Override
     public boolean isValid(LocalDate value, ConstraintValidatorContext context) {
-        LocalDate today = LocalDate.now();
+        if (value == null) {
+            addConstraintViolation(context, NULL_ERROR_MESSAGE);
+            return false;
+        }
 
+        LocalDate today = LocalDate.now();
         if (today.isAfter(value)) {
-            addConstraintViolation(context, MESSAGE);
+            addConstraintViolation(context, INVALID_EXPIRE_DATE_MESSAGE);
             return false;
         }
 

--- a/src/main/java/kr/lnsc/api/linkhistory/domain/LinkHistory.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/domain/LinkHistory.java
@@ -1,0 +1,32 @@
+package kr.lnsc.api.linkhistory.domain;
+
+import jakarta.persistence.*;
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.model.TimeBaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@AttributeOverride(name = "createdAt", column = @Column(name = "accessedAt", updatable = false, columnDefinition = "datetime(6)"))
+public class LinkHistory extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "link_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Link link;
+
+    private LinkHistory(Long id, Link link) {
+        this.id = id;
+        this.link = link;
+    }
+
+    public static LinkHistory from(Link link) {
+        return new LinkHistory(null, link);
+    }
+}

--- a/src/main/java/kr/lnsc/api/linkhistory/dto/LinkAccessCountDto.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/dto/LinkAccessCountDto.java
@@ -1,0 +1,31 @@
+package kr.lnsc.api.linkhistory.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+@Getter
+public class LinkAccessCountDto {
+
+    @Schema(description = "접속 일자")
+    private LocalDate date;
+
+    @Schema(description = "접속 횟수")
+    private long count;
+
+    public LinkAccessCountDto(LocalDate date, long count) {
+        this.date = date;
+        this.count = count;
+    }
+
+    public LinkAccessCountDto(Date date, long count) {
+        this.date = date.toLocalDate();
+        this.count = count;
+    }
+
+    public boolean isEqualDate(LocalDate date) {
+        return this.date.isEqual(date);
+    }
+}

--- a/src/main/java/kr/lnsc/api/linkhistory/repository/LinkHistoryRepository.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/repository/LinkHistoryRepository.java
@@ -1,0 +1,7 @@
+package kr.lnsc.api.linkhistory.repository;
+
+import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LinkHistoryRepository extends JpaRepository<LinkHistory, Long> {
+}

--- a/src/main/java/kr/lnsc/api/linkhistory/repository/LinkHistoryRepository.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/repository/LinkHistoryRepository.java
@@ -1,7 +1,19 @@
 package kr.lnsc.api.linkhistory.repository;
 
+import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import kr.lnsc.api.linkhistory.dto.LinkAccessCountDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface LinkHistoryRepository extends JpaRepository<LinkHistory, Long> {
+
+    @Query("SELECT new kr.lnsc.api.linkhistory.dto.LinkAccessCountDto(date(lh.createdAt) as date_only, count(1)) " +
+            "FROM LinkHistory lh " +
+            "WHERE lh.link = :link " +
+            "GROUP BY date_only " +
+            "ORDER BY date_only")
+    List<LinkAccessCountDto> findAccessCountByDate(Link link);
 }

--- a/src/main/java/kr/lnsc/api/linkhistory/repository/LinkHistoryRepository.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/repository/LinkHistoryRepository.java
@@ -16,4 +16,6 @@ public interface LinkHistoryRepository extends JpaRepository<LinkHistory, Long> 
             "GROUP BY date_only " +
             "ORDER BY date_only")
     List<LinkAccessCountDto> findAccessCountByDate(Link link);
+
+    void deleteAllByLink(Link link);
 }

--- a/src/main/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommand.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommand.java
@@ -25,4 +25,8 @@ public class LinkHistoryCommand {
         this.createHistory(findLink);
         return findLink;
     }
+
+    public void removeAllLinkHistory(Link link) {
+        linkHistoryRepository.deleteAllByLink(link);
+    }
 }

--- a/src/main/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommand.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommand.java
@@ -1,0 +1,28 @@
+package kr.lnsc.api.linkhistory.service;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.service.LinkQuery;
+import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import kr.lnsc.api.linkhistory.repository.LinkHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class LinkHistoryCommand {
+    private final LinkHistoryRepository linkHistoryRepository;
+    private final LinkQuery linkQuery;
+
+    public LinkHistory createHistory(Link link) {
+        LinkHistory newLinkHistory = LinkHistory.from(link);
+        return linkHistoryRepository.save(newLinkHistory);
+    }
+
+    public Link accessLink(String shortenPath) {
+        Link findLink = linkQuery.getLink(shortenPath);
+        this.createHistory(findLink);
+        return findLink;
+    }
+}

--- a/src/main/java/kr/lnsc/api/linkhistory/service/LinkHistoryQuery.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/service/LinkHistoryQuery.java
@@ -1,0 +1,37 @@
+package kr.lnsc.api.linkhistory.service;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.linkhistory.dto.LinkAccessCountDto;
+import kr.lnsc.api.linkhistory.repository.LinkHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class LinkHistoryQuery {
+    private final LinkHistoryRepository linkHistoryRepository;
+
+    public List<LinkAccessCountDto> getAccessCountByDate(Link link) {
+        return linkHistoryRepository.findAccessCountByDate(link);
+    }
+
+    public long getAccessCount(Link link, LocalDate date) {
+        return getAccessCountByDate(link).stream()
+                .filter(ac -> ac.isEqualDate(date))
+                .map(LinkAccessCountDto::getCount)
+                .findFirst()
+                .orElse(0l);
+    }
+
+    public long getTotalAccessCount(Link link) {
+        return getAccessCountByDate(link).stream()
+                .map(LinkAccessCountDto::getCount)
+                .reduce(Long::sum)
+                .orElse(0l);
+    }
+}

--- a/src/main/java/kr/lnsc/api/log/P6SpySqlFormatter.java
+++ b/src/main/java/kr/lnsc/api/log/P6SpySqlFormatter.java
@@ -1,0 +1,39 @@
+package kr.lnsc.api.log;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import jakarta.annotation.PostConstruct;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+
+@Component
+public class P6SpySqlFormatter implements MessageFormattingStrategy {
+
+    @PostConstruct
+    public void setLogMessageFormat() {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(this.getClass().getName());
+    }
+
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
+        sql = formatSql(category, sql);
+        return String.format("[%s] | %d ms | %s", category, elapsed, formatSql(category, sql));
+    }
+
+    private String formatSql(String category, String sql) {
+        if (sql != null && !sql.trim().isEmpty() && Category.STATEMENT.getName().equals(category)) {
+            String trimmedSQL = sql.trim().toLowerCase(Locale.ROOT);
+            if (trimmedSQL.startsWith("create") || trimmedSQL.startsWith("alter") || trimmedSQL.startsWith("comment")) {
+                sql = FormatStyle.DDL.getFormatter().format(sql);
+            } else {
+                sql = FormatStyle.BASIC.getFormatter().format(sql);
+            }
+            return sql;
+        }
+        return sql;
+    }
+
+}

--- a/src/main/java/kr/lnsc/api/model/TimeBaseEntity.java
+++ b/src/main/java/kr/lnsc/api/model/TimeBaseEntity.java
@@ -1,0 +1,20 @@
+package kr.lnsc.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class TimeBaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, columnDefinition = "datetime(6)")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/kr/lnsc/api/property/BaseUrlProperty.java
+++ b/src/main/java/kr/lnsc/api/property/BaseUrlProperty.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 public class BaseUrlProperty {
     private static String baseUrl;
 
-    public BaseUrlProperty(@Value("${env.base-url}") String baseUrl) {
+    public BaseUrlProperty(@Value("${base-url}") String baseUrl) {
         this.baseUrl = baseUrl;
     }
 

--- a/src/main/java/kr/lnsc/api/property/BaseUrlProperty.java
+++ b/src/main/java/kr/lnsc/api/property/BaseUrlProperty.java
@@ -1,0 +1,17 @@
+package kr.lnsc.api.property;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BaseUrlProperty {
+    private static String baseUrl;
+
+    public BaseUrlProperty(@Value("${env.base-url}") String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public static String getBaseUrl() {
+        return baseUrl;
+    }
+}

--- a/src/main/resources-dev/application-dev.yml
+++ b/src/main/resources-dev/application-dev.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${dev-db-url}
+    username: ${dev-db-user}
+    password: ${dev-db-pw}

--- a/src/main/resources-prod/application-prod.yml
+++ b/src/main/resources-prod/application-prod.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${prod-db-url}
+    username: ${prod-db-user}
+    password: ${prod-db-pw}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,20 @@
+server:
+  port: 8080
+  servlet:
+    encoding:
+      charset: UTF-8
+      force-response: true
 
+spring:
+  profiles:
+    group:
+      dev: "dev,env"
+    active: dev
+
+  jpa:
+    show-sql: false
+    open-in-view: false
+
+    properties:
+      hibernate:
+        show_sql: false

--- a/src/test/java/kr/lnsc/api/domain/link/UrlTest.java
+++ b/src/test/java/kr/lnsc/api/domain/link/UrlTest.java
@@ -1,0 +1,41 @@
+package kr.lnsc.api.domain.link;
+
+import kr.lnsc.api.domain.link.exception.InvalidUrlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UrlTest {
+    private static final String VALID_URL = "http://www.example.com";
+
+    @DisplayName("URL 생성에 성공한다.")
+    @Test
+    void createUrlSuccess() {
+        new Url(VALID_URL);
+    }
+
+    private static Stream<Arguments> invalidUrls() {
+        return Stream.of(
+                Arguments.of(""),
+                Arguments.of(VALID_URL + "a".repeat(2048)),
+                Arguments.of(VALID_URL + "/aa!@##$"),
+                Arguments.of(VALID_URL + "/aaa?abcd,gef")
+        );
+    }
+
+    @DisplayName("유효하지 않은 URL일 경우 예외가 발생한다.")
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("invalidUrls")
+    void invalidUrlFail(String invalidUrl) {
+        assertThatThrownBy(() -> new Url(invalidUrl))
+                .isInstanceOf(InvalidUrlException.class);
+    }
+}

--- a/src/test/java/kr/lnsc/api/domain/link/UrlTest.java
+++ b/src/test/java/kr/lnsc/api/domain/link/UrlTest.java
@@ -1,6 +1,7 @@
 package kr.lnsc.api.domain.link;
 
-import kr.lnsc.api.domain.link.exception.InvalidUrlException;
+import kr.lnsc.api.link.domain.Url;
+import kr.lnsc.api.link.exception.InvalidUrlException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/kr/lnsc/api/fixture/HttpMethodFixture.java
+++ b/src/test/java/kr/lnsc/api/fixture/HttpMethodFixture.java
@@ -1,0 +1,31 @@
+package kr.lnsc.api.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+public class HttpMethodFixture {
+
+    public static ExtractableResponse<Response> httpGet(String path) {
+        return RestAssured
+                .given().redirects().follow(false).log().all()
+                .when().get(path)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> httpPost(Object postRequest, String path) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(postRequest)
+                .when().post(path)
+                .then().log().all()
+                .extract();
+    }
+
+    public static String getExceptionMessage(ExtractableResponse<Response> response) {
+        return response.jsonPath().getString("message");
+    }
+}

--- a/src/test/java/kr/lnsc/api/fixture/LinkFixture.java
+++ b/src/test/java/kr/lnsc/api/fixture/LinkFixture.java
@@ -7,7 +7,8 @@ import java.time.LocalDate;
 
 public enum LinkFixture {
     EXAMPLE_TODAY_EXPIRED(new Url("http://www.example.com"), "aaaaaaa", "12345678", LocalDate.now()),
-    EXAMPLE_NEXT_DAY_EXPIRED(new Url("http://www.example.com"), "bbbbbbb", "11111111", LocalDate.now().plusDays(1));
+    EXAMPLE_NEXT_DAY_EXPIRED(new Url("http://www.example.com"), "bbbbbbb", "11111111", LocalDate.now().plusDays(1)),
+    EXAMPLE_ALREADY_EXPIRED(new Url("http://www.example.com"), "ccccccc", "87654321", LocalDate.now().minusDays(1));
 
     public final Url originalUrl;
     public final String shortenPath;

--- a/src/test/java/kr/lnsc/api/fixture/LinkFixture.java
+++ b/src/test/java/kr/lnsc/api/fixture/LinkFixture.java
@@ -1,0 +1,27 @@
+package kr.lnsc.api.fixture;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.domain.Url;
+
+import java.time.LocalDate;
+
+public enum LinkFixture {
+    EXAMPLE_TODAY_EXPIRED(new Url("http://www.example.com"), "aaaaaaa", "12345678", LocalDate.now()),
+    EXAMPLE_NEXT_DAY_EXPIRED(new Url("http://www.example.com"), "bbbbbbb", "11111111", LocalDate.now().plusDays(1));
+
+    public final Url originalUrl;
+    public final String shortenPath;
+    public final String expireKey;
+    public final LocalDate expireDate;
+
+    LinkFixture(Url originalUrl, String shortenPath, String expireKey, LocalDate expireDate) {
+        this.originalUrl = originalUrl;
+        this.shortenPath = shortenPath;
+        this.expireKey = expireKey;
+        this.expireDate = expireDate;
+    }
+
+    public Link toLink() {
+        return Link.createLink(originalUrl, shortenPath, expireKey, expireDate);
+    }
+}

--- a/src/test/java/kr/lnsc/api/fixture/LinkHistoryFixture.java
+++ b/src/test/java/kr/lnsc/api/fixture/LinkHistoryFixture.java
@@ -1,0 +1,25 @@
+package kr.lnsc.api.fixture;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+public enum LinkHistoryFixture {
+    ACCESS_TODAY(LocalDateTime.now()),
+    ACCESS_YESTERDAY(LocalDateTime.now().minusDays(1)),
+    ACCESS_LAST_WEEK(LocalDateTime.now().minusWeeks(1));
+
+    public final LocalDateTime accessedAt;
+
+    LinkHistoryFixture(LocalDateTime accessedAt) {
+        this.accessedAt = accessedAt;
+    }
+
+    public LinkHistory toLinkHistory(Link link) {
+        LinkHistory newLinkHistory = LinkHistory.from(link);
+        ReflectionTestUtils.setField(newLinkHistory, "createdAt", accessedAt);
+        return newLinkHistory;
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/acceptance/LinkAcceptanceTest.java
+++ b/src/test/java/kr/lnsc/api/link/acceptance/LinkAcceptanceTest.java
@@ -1,0 +1,128 @@
+package kr.lnsc.api.link.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.dto.request.ExpireShortenLinkRequest;
+import kr.lnsc.api.link.dto.response.CreateShortenLinkResponse;
+import kr.lnsc.api.link.dto.response.GetLinkStatInfoResponse;
+import kr.lnsc.api.util.AcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static kr.lnsc.api.fixture.HttpMethodFixture.*;
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_ALREADY_EXPIRED;
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LinkAcceptanceTest extends AcceptanceTest {
+
+    @DisplayName("단축 URL을 생성한다.")
+    @Test
+    void createLink() {
+        CreateShortenLinkRequest request =
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
+
+        ExtractableResponse<Response> response = httpPost(request, "/api/link/create");
+        CreateShortenLinkResponse responseDto = response.body().as(CreateShortenLinkResponse.class);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(responseDto.getShortenUrl()).isNotNull();
+        assertThat(responseDto.getExpireKey()).isNotNull();
+        assertThat(responseDto.getExpiredAt()).isEqualTo(toExpiredAt(EXAMPLE_TODAY_EXPIRED.expireDate));
+    }
+
+    @DisplayName("같은 URL로 여러개의 단축 URL을 생성한다.")
+    @Test
+    void createLinkWithSameOriginalURL() {
+        CreateShortenLinkRequest request =
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
+
+        ExtractableResponse<Response> firstResponse = httpPost(request, "/api/link/create");
+        assertThat(firstResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        ExtractableResponse<Response> secondResponse = httpPost(request, "/api/link/create");
+        assertThat(secondResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @DisplayName("단축 URL로 접속하면 원래 URL로 리다이렉트한다.")
+    @Test
+    void accessToLink() {
+        ExtractableResponse<Response> response = httpGet("/" + EXAMPLE_TODAY_EXPIRED.shortenPath);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FOUND.value());
+        assertThat(response.header(HttpHeaders.LOCATION))
+                .isEqualTo(EXAMPLE_TODAY_EXPIRED.originalUrl.getValue());
+    }
+
+    @DisplayName("만료된 단축 URL로 접속하면 404 에러가 발생한다.")
+    @Test
+    void accessToExpiredOrNotExistLink() {
+        ExtractableResponse<Response> response = httpGet("/" + EXAMPLE_ALREADY_EXPIRED.shortenPath);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(getExceptionMessage(response))
+                .isEqualTo("해당 링크가 이미 만료되었거나 존재하지 않아 불러올 수 없습니다.");
+    }
+
+    @DisplayName("단축 URL을 만료시킨다.")
+    @Test
+    void expireLink() {
+        ExpireShortenLinkRequest request =
+                new ExpireShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.shortenPath, EXAMPLE_TODAY_EXPIRED.expireKey);
+
+        ExtractableResponse<Response> response = httpPost(request, "/api/link/expire");
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @DisplayName("단축 URL 만료시 유효하지 않은 만료키를 입력하면 400 에러가 발생한다.")
+    @Test
+    void expireLinkWithInvalidExpireKey() {
+        final String INVALID_EXPIRE_KEY = "INVALID" + EXAMPLE_TODAY_EXPIRED.expireKey;
+        ExpireShortenLinkRequest request =
+                new ExpireShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.shortenPath, INVALID_EXPIRE_KEY);
+
+        ExtractableResponse<Response> response = httpPost(request, "/api/link/expire");
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(getExceptionMessage(response))
+                .isEqualTo("만료키가 일치하지 않거나 유효하지 않는 만료키입니다. 확인 후 다시 입력해주세요.");
+    }
+
+    @DisplayName("단축 URL의 통계 정보를 조회한다.")
+    @Test
+    void getLinkStats() {
+        ExtractableResponse<Response> response =
+                httpGet("/api/link/" + EXAMPLE_TODAY_EXPIRED.shortenPath);
+        GetLinkStatInfoResponse responseDto = response.body().as(GetLinkStatInfoResponse.class);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(responseDto.getOriginalUrl()).isEqualTo(EXAMPLE_TODAY_EXPIRED.originalUrl.getValue());
+        assertThat(responseDto.getDailyAccessCount()).isEqualTo(0L);
+        assertThat(responseDto.getTotalAccessCount()).isEqualTo(1L);
+        assertThat(responseDto.getCreatedAt()).isNotNull();
+        assertThat(responseDto.getExpiredAt()).isEqualTo(toExpiredAt(EXAMPLE_TODAY_EXPIRED.expireDate));
+    }
+
+    @DisplayName("만료된 단축 URL로 통계 정보를 조회할 경우 404 에러가 발생한다.")
+    @Test
+    void getExpiredLinkStats() {
+        ExtractableResponse<Response> response =
+                httpGet("/api/link/" + EXAMPLE_ALREADY_EXPIRED.shortenPath);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(getExceptionMessage(response))
+                .isEqualTo("해당 링크가 이미 만료되었거나 존재하지 않아 불러올 수 없습니다.");
+    }
+
+    private LocalDateTime toExpiredAt(LocalDate expireDate) {
+        return LocalDateTime.of(expireDate.plusDays(1), LocalTime.MIN);
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/controller/ControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/ControllerTest.java
@@ -1,0 +1,33 @@
+package kr.lnsc.api.link.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import kr.lnsc.api.property.BaseUrlProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@WebMvcTest(LinkController.class)
+@Import(BaseUrlProperty.class)
+public class ControllerTest {
+    protected MockMvc mockMvc;
+
+    protected ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
+                .build();
+
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
@@ -1,71 +1,19 @@
 package kr.lnsc.api.link.controller;
 
-import kr.lnsc.api.link.domain.Link;
-import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
-import kr.lnsc.api.link.dto.request.ExpireShortenLinkRequest;
-import kr.lnsc.api.link.service.LinkCommand;
-import kr.lnsc.api.link.service.LinkQuery;
-import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
-import kr.lnsc.api.linkhistory.service.LinkHistoryQuery;
 import kr.lnsc.api.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 
 import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-class LinkControllerTest extends ControllerTest {
-
-    @MockBean
-    private LinkCommand linkCommand;
-
-    @MockBean
-    private LinkQuery linkQuery;
-
-    @MockBean
-    private LinkHistoryCommand linkHistoryCommand;
-
-    @MockBean
-    private LinkHistoryQuery linkHistoryQuery;
-
-    @DisplayName("입력한 값을 바탕으로 단축 URL을 생성한다.")
-    @Test
-    void createShortenLink() throws Exception {
-        CreateShortenLinkRequest request =
-                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
-
-        given(linkCommand.createLink(any(CreateShortenLinkRequest.class)))
-                .willReturn(EXAMPLE_TODAY_EXPIRED.toLink());
-
-        LocalDateTime expectedExpiredAt =
-                LocalDateTime.of(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1), LocalTime.MIN);
-        mockMvc.perform(
-                        post("/api/v1/create")
-                                .contentType(APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsBytes(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.shortenUrl")
-                        .value("https://www.test.kr/" + EXAMPLE_TODAY_EXPIRED.shortenPath))
-                .andExpect(jsonPath("$.expiredAt")
-                        .value(toIsoLocalDateTime(expectedExpiredAt)))
-                .andExpect(jsonPath("$.expireKey").value(EXAMPLE_TODAY_EXPIRED.expireKey));
-    }
+public class LinkControllerTest extends ControllerTest {
 
     @DisplayName("단축 URL로 접속 요쳥시 원래 URL로 리다이렉트한다.")
     @Test
@@ -77,51 +25,5 @@ class LinkControllerTest extends ControllerTest {
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string(HttpHeaders.LOCATION, EXAMPLE_TODAY_EXPIRED.originalUrl.getValue()));
-    }
-
-    @DisplayName("단축 URL의 통계 정보를 반환한다.")
-    @Test
-    void getLinkStatisticalInformation() throws Exception {
-        Link link = EXAMPLE_TODAY_EXPIRED.toLink();
-        LocalDateTime now = LocalDateTime.now();
-        ReflectionTestUtils.setField(link, "createdAt", now);
-
-        given(linkQuery.getLink(anyString()))
-                .willReturn(link);
-        given(linkHistoryQuery.getAccessCount(any(Link.class), any(LocalDate.class)))
-                .willReturn(0L);
-        given(linkHistoryQuery.getTotalAccessCount(any(Link.class)))
-                .willReturn(2L);
-
-        LocalDateTime expectedExpiredAt =
-                LocalDateTime.of(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1), LocalTime.MIN);
-
-        mockMvc.perform(get("/{shortenPath}/info", EXAMPLE_TODAY_EXPIRED.shortenPath)
-                        .contentType(APPLICATION_JSON))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(jsonPath("$.originalUrl").value("http://www.example.com"))
-                .andExpect(jsonPath("$.dailyAccessCount").value(0L))
-                .andExpect(jsonPath("$.totalAccessCount").value(2L))
-                .andExpect(jsonPath("$.expiredAt").value(toIsoLocalDateTime(expectedExpiredAt)))
-                .andExpect(jsonPath("$.createdAt").value(toIsoLocalDateTime(now)));
-    }
-
-    @DisplayName("단축 URL을 임의로 만료시키며, 단축 URL 통계 정보를 삭제한다.")
-    @Test
-    void expireShortenLink() throws Exception {
-        ExpireShortenLinkRequest request =
-                new ExpireShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.shortenPath, EXAMPLE_TODAY_EXPIRED.expireKey);
-
-        mockMvc.perform(
-                        post("/api/v1/expire")
-                                .contentType(APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsBytes(request)))
-                .andExpect(status().isOk());
-
-        verify(linkCommand, times(1)).expireLink(any(ExpireShortenLinkRequest.class));
-    }
-
-    private static String toIsoLocalDateTime(LocalDateTime time) {
-        return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(time);
     }
 }

--- a/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
@@ -2,7 +2,8 @@ package kr.lnsc.api.link.controller;
 
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
 import kr.lnsc.api.link.service.LinkCommand;
-import kr.lnsc.api.link.service.LinkHistoryCommand;
+import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
+import kr.lnsc.api.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
@@ -53,6 +53,18 @@ class LinkControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.expireKey").value(EXAMPLE_TODAY_EXPIRED.expireKey));
     }
 
+    @DisplayName("단축 URL로 접속 요쳥시 원래 URL로 리다이렉트한다.")
+    @Test
+    void accessLink() throws Exception {
+        given(linkHistoryCommand.accessLink(anyString()))
+                .willReturn(EXAMPLE_TODAY_EXPIRED.toLink());
+
+        mockMvc.perform(get("/{shortenPath}", EXAMPLE_TODAY_EXPIRED.shortenPath)
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(HttpHeaders.LOCATION, EXAMPLE_TODAY_EXPIRED.originalUrl.getValue()));
+    }
+
     private static String toIsoLocalDateTime(LocalDateTime time) {
         return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(time);
     }

--- a/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
@@ -1,0 +1,54 @@
+package kr.lnsc.api.link.controller;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.domain.Url;
+import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.service.LinkCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LinkControllerTest extends ControllerTest {
+
+    @MockBean
+    private LinkCommand linkCommand;
+
+    @DisplayName("입력한 값을 바탕으로 단축 URL을 생성한다.")
+    @Test
+    void createShortenLink() throws Exception {
+        final Url ORIGINAL_URL = new Url("http://www.example.com");
+        final String SHORTEN_PATH = "aaaaaaa";
+        final String EXPIRE_KEY = "12345678";
+        LocalDate TODAY = LocalDate.now();
+
+        CreateShortenLinkRequest request = new CreateShortenLinkRequest(ORIGINAL_URL, TODAY);
+        given(linkCommand.createLink(any(CreateShortenLinkRequest.class)))
+                .willReturn(Link.createLink(ORIGINAL_URL, SHORTEN_PATH, EXPIRE_KEY, TODAY));
+
+        LocalDateTime expectedExpiredAt = LocalDateTime.of(TODAY.plusDays(1), LocalTime.MIN);
+        mockMvc.perform(
+                        post("/api/v1/create")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.shortenUrl").value("https://www.test.kr/" + SHORTEN_PATH))
+                .andExpect(jsonPath("$.expiredAt").value(toIsoLocalDateTime(expectedExpiredAt)))
+                .andExpect(jsonPath("$.expireKey").value(EXPIRE_KEY));
+    }
+
+    private static String toIsoLocalDateTime(LocalDateTime time) {
+        return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(time);
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
@@ -1,51 +1,55 @@
 package kr.lnsc.api.link.controller;
 
-import kr.lnsc.api.link.domain.Link;
-import kr.lnsc.api.link.domain.Url;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
 import kr.lnsc.api.link.service.LinkCommand;
+import kr.lnsc.api.link.service.LinkHistoryCommand;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 class LinkControllerTest extends ControllerTest {
 
     @MockBean
     private LinkCommand linkCommand;
 
+    @MockBean
+    private LinkHistoryCommand linkHistoryCommand;
+
     @DisplayName("입력한 값을 바탕으로 단축 URL을 생성한다.")
     @Test
     void createShortenLink() throws Exception {
-        final Url ORIGINAL_URL = new Url("http://www.example.com");
-        final String SHORTEN_PATH = "aaaaaaa";
-        final String EXPIRE_KEY = "12345678";
-        LocalDate TODAY = LocalDate.now();
+        CreateShortenLinkRequest request =
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
 
-        CreateShortenLinkRequest request = new CreateShortenLinkRequest(ORIGINAL_URL, TODAY);
         given(linkCommand.createLink(any(CreateShortenLinkRequest.class)))
-                .willReturn(Link.createLink(ORIGINAL_URL, SHORTEN_PATH, EXPIRE_KEY, TODAY));
+                .willReturn(EXAMPLE_TODAY_EXPIRED.toLink());
 
-        LocalDateTime expectedExpiredAt = LocalDateTime.of(TODAY.plusDays(1), LocalTime.MIN);
+        LocalDateTime expectedExpiredAt =
+                LocalDateTime.of(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1), LocalTime.MIN);
         mockMvc.perform(
                         post("/api/v1/create")
                                 .contentType(APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsBytes(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.shortenUrl").value("https://www.test.kr/" + SHORTEN_PATH))
-                .andExpect(jsonPath("$.expiredAt").value(toIsoLocalDateTime(expectedExpiredAt)))
-                .andExpect(jsonPath("$.expireKey").value(EXPIRE_KEY));
+                .andExpect(jsonPath("$.shortenUrl")
+                        .value("https://www.test.kr/" + EXAMPLE_TODAY_EXPIRED.shortenPath))
+                .andExpect(jsonPath("$.expiredAt")
+                        .value(toIsoLocalDateTime(expectedExpiredAt)))
+                .andExpect(jsonPath("$.expireKey").value(EXAMPLE_TODAY_EXPIRED.expireKey));
     }
 
     private static String toIsoLocalDateTime(LocalDateTime time) {

--- a/src/test/java/kr/lnsc/api/link/controller/LinkRestControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkRestControllerTest.java
@@ -39,7 +39,7 @@ class LinkRestControllerTest extends ControllerTest {
         LocalDateTime expectedExpiredAt =
                 LocalDateTime.of(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1), LocalTime.MIN);
         mockMvc.perform(
-                        post("/api/v1/create")
+                        post("/api/link/create")
                                 .contentType(APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsBytes(request)))
                 .andExpect(status().isOk())
@@ -67,7 +67,7 @@ class LinkRestControllerTest extends ControllerTest {
         LocalDateTime expectedExpiredAt =
                 LocalDateTime.of(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1), LocalTime.MIN);
 
-        mockMvc.perform(get("/{shortenPath}/info", EXAMPLE_TODAY_EXPIRED.shortenPath)
+        mockMvc.perform(get("/api/link/{shortenPath}", EXAMPLE_TODAY_EXPIRED.shortenPath)
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(jsonPath("$.originalUrl").value("http://www.example.com"))
@@ -84,7 +84,7 @@ class LinkRestControllerTest extends ControllerTest {
                 new ExpireShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.shortenPath, EXAMPLE_TODAY_EXPIRED.expireKey);
 
         mockMvc.perform(
-                        post("/api/v1/expire")
+                        post("/api/link/expire")
                                 .contentType(APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsBytes(request)))
                 .andExpect(status().isOk());

--- a/src/test/java/kr/lnsc/api/link/controller/LinkRestControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkRestControllerTest.java
@@ -1,0 +1,98 @@
+package kr.lnsc.api.link.controller;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.dto.request.ExpireShortenLinkRequest;
+import kr.lnsc.api.util.ControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LinkRestControllerTest extends ControllerTest {
+
+    @DisplayName("입력한 값을 바탕으로 단축 URL을 생성한다.")
+    @Test
+    void createShortenLink() throws Exception {
+        CreateShortenLinkRequest request =
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
+
+        given(linkCommand.createLink(any(CreateShortenLinkRequest.class)))
+                .willReturn(EXAMPLE_TODAY_EXPIRED.toLink());
+
+        LocalDateTime expectedExpiredAt =
+                LocalDateTime.of(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1), LocalTime.MIN);
+        mockMvc.perform(
+                        post("/api/v1/create")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.shortenUrl")
+                        .value("https://www.test.kr/" + EXAMPLE_TODAY_EXPIRED.shortenPath))
+                .andExpect(jsonPath("$.expiredAt")
+                        .value(toIsoLocalDateTime(expectedExpiredAt)))
+                .andExpect(jsonPath("$.expireKey").value(EXAMPLE_TODAY_EXPIRED.expireKey));
+    }
+
+    @DisplayName("단축 URL의 통계 정보를 반환한다.")
+    @Test
+    void getLinkStatisticalInformation() throws Exception {
+        Link link = EXAMPLE_TODAY_EXPIRED.toLink();
+        LocalDateTime now = LocalDateTime.now();
+        ReflectionTestUtils.setField(link, "createdAt", now);
+
+        given(linkQuery.getLink(anyString()))
+                .willReturn(link);
+        given(linkHistoryQuery.getAccessCount(any(Link.class), any(LocalDate.class)))
+                .willReturn(0L);
+        given(linkHistoryQuery.getTotalAccessCount(any(Link.class)))
+                .willReturn(2L);
+
+        LocalDateTime expectedExpiredAt =
+                LocalDateTime.of(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1), LocalTime.MIN);
+
+        mockMvc.perform(get("/{shortenPath}/info", EXAMPLE_TODAY_EXPIRED.shortenPath)
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(jsonPath("$.originalUrl").value("http://www.example.com"))
+                .andExpect(jsonPath("$.dailyAccessCount").value(0L))
+                .andExpect(jsonPath("$.totalAccessCount").value(2L))
+                .andExpect(jsonPath("$.expiredAt").value(toIsoLocalDateTime(expectedExpiredAt)))
+                .andExpect(jsonPath("$.createdAt").value(toIsoLocalDateTime(now)));
+    }
+
+    @DisplayName("단축 URL을 임의로 만료시키며, 단축 URL 통계 정보를 삭제한다.")
+    @Test
+    void expireShortenLink() throws Exception {
+        ExpireShortenLinkRequest request =
+                new ExpireShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.shortenPath, EXAMPLE_TODAY_EXPIRED.expireKey);
+
+        mockMvc.perform(
+                        post("/api/v1/expire")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk());
+
+        verify(linkCommand, times(1)).expireLink(any(ExpireShortenLinkRequest.class));
+    }
+
+    private static String toIsoLocalDateTime(LocalDateTime time) {
+        return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(time);
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
+++ b/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
@@ -3,9 +3,11 @@ package kr.lnsc.api.link.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_NEXT_DAY_EXPIRED;
 import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,5 +25,24 @@ class LinkTest {
         LocalDateTime expiredAt = newLink.getExpiredAt();
         assertThat(expiredAt.toLocalDate()).isEqualTo(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1));
         assertThat(expiredAt.toLocalTime()).isEqualTo(LocalTime.MIN);
+    }
+
+    @DisplayName("원본 URI을 반환한다.")
+    @Test
+    void originalUri() {
+        Link link = EXAMPLE_TODAY_EXPIRED.toLink();
+        URI originalUri = link.originalUri();
+        assertThat(originalUri.toString()).isEqualTo("http://www.example.com");
+    }
+
+    @DisplayName("만료키가 같으면 true, 다르면 false를 반환한다.")
+    @Test
+    void isSameExpireKey() {
+        Link link = EXAMPLE_TODAY_EXPIRED.toLink();
+        boolean sameExpireKey = link.isSameExpireKey(EXAMPLE_TODAY_EXPIRED.expireKey);
+        assertThat(sameExpireKey).isTrue();
+
+        boolean notSameExpireKey = link.isSameExpireKey(EXAMPLE_NEXT_DAY_EXPIRED.expireKey);
+        assertThat(notSameExpireKey).isFalse();
     }
 }

--- a/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
+++ b/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
@@ -3,10 +3,10 @@ package kr.lnsc.api.link.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LinkTest {
@@ -14,19 +14,14 @@ class LinkTest {
     @DisplayName("새로운 Link 생성에 성공한다.")
     @Test
     void createLinkSuccess() {
-        final Url ORIGINAL_URL = new Url("http://www.example.com");
-        final String SHORTEN_PATH = "aaaaaaa";
-        final String EXPIRE_KEY = "12345678";
-        final LocalDate TODAY = LocalDate.now();
+        Link newLink = Link.createLink(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.shortenPath, EXAMPLE_TODAY_EXPIRED.expireKey, EXAMPLE_TODAY_EXPIRED.expireDate);
 
-        Link newLink = Link.createLink(ORIGINAL_URL, SHORTEN_PATH, EXPIRE_KEY, TODAY);
-
-        assertThat(newLink.getOriginalUrl()).isEqualTo(ORIGINAL_URL);
-        assertThat(newLink.getShortenPath()).isEqualTo(SHORTEN_PATH);
-        assertThat(newLink.getExpireKey()).isEqualTo(EXPIRE_KEY);
+        assertThat(newLink.getOriginalUrl()).isEqualTo(EXAMPLE_TODAY_EXPIRED.originalUrl);
+        assertThat(newLink.getShortenPath()).isEqualTo(EXAMPLE_TODAY_EXPIRED.shortenPath);
+        assertThat(newLink.getExpireKey()).isEqualTo(EXAMPLE_TODAY_EXPIRED.expireKey);
 
         LocalDateTime expiredAt = newLink.getExpiredAt();
-        assertThat(expiredAt.toLocalDate()).isEqualTo(TODAY.plusDays(1));
+        assertThat(expiredAt.toLocalDate()).isEqualTo(EXAMPLE_TODAY_EXPIRED.expireDate.plusDays(1));
         assertThat(expiredAt.toLocalTime()).isEqualTo(LocalTime.MIN);
     }
 }

--- a/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
+++ b/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
@@ -1,0 +1,32 @@
+package kr.lnsc.api.link.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LinkTest {
+
+    @DisplayName("새로운 Link 생성에 성공한다.")
+    @Test
+    void createLinkSuccess() {
+        final Url ORIGINAL_URL = new Url("http://www.example.com");
+        final String SHORTEN_PATH = "aaaaaaa";
+        final String EXPIRE_KEY = "12345678";
+        final LocalDate TODAY = LocalDate.now();
+
+        Link newLink = Link.createLink(ORIGINAL_URL, SHORTEN_PATH, EXPIRE_KEY, TODAY);
+
+        assertThat(newLink.getOriginalUrl()).isEqualTo(ORIGINAL_URL);
+        assertThat(newLink.getShortenPath()).isEqualTo(SHORTEN_PATH);
+        assertThat(newLink.getExpiredKey()).isEqualTo(EXPIRE_KEY);
+
+        LocalDateTime expiredAt = newLink.getExpiredAt();
+        assertThat(expiredAt.toLocalDate()).isEqualTo(TODAY);
+        assertThat(expiredAt.toLocalTime()).isEqualTo(LocalTime.MAX);
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
+++ b/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
@@ -26,7 +26,7 @@ class LinkTest {
         assertThat(newLink.getExpireKey()).isEqualTo(EXPIRE_KEY);
 
         LocalDateTime expiredAt = newLink.getExpiredAt();
-        assertThat(expiredAt.toLocalDate()).isEqualTo(TODAY);
-        assertThat(expiredAt.toLocalTime()).isEqualTo(LocalTime.MAX);
+        assertThat(expiredAt.toLocalDate()).isEqualTo(TODAY.plusDays(1));
+        assertThat(expiredAt.toLocalTime()).isEqualTo(LocalTime.MIN);
     }
 }

--- a/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
+++ b/src/test/java/kr/lnsc/api/link/domain/LinkTest.java
@@ -23,7 +23,7 @@ class LinkTest {
 
         assertThat(newLink.getOriginalUrl()).isEqualTo(ORIGINAL_URL);
         assertThat(newLink.getShortenPath()).isEqualTo(SHORTEN_PATH);
-        assertThat(newLink.getExpiredKey()).isEqualTo(EXPIRE_KEY);
+        assertThat(newLink.getExpireKey()).isEqualTo(EXPIRE_KEY);
 
         LocalDateTime expiredAt = newLink.getExpiredAt();
         assertThat(expiredAt.toLocalDate()).isEqualTo(TODAY);

--- a/src/test/java/kr/lnsc/api/link/domain/generator/RandomShortenPathGeneratorTest.java
+++ b/src/test/java/kr/lnsc/api/link/domain/generator/RandomShortenPathGeneratorTest.java
@@ -1,0 +1,40 @@
+package kr.lnsc.api.link.domain.generator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RandomShortenPathGeneratorTest {
+    private Set<Character> pathAvailableCharacters = pathAvailableCharacters();
+    private RandomShortenPathGenerator generator = new RandomShortenPathGenerator();
+
+    @DisplayName("생성된 단축 Path는 대소문자 구분 가능한 영어 알파벳 7자리의 조합이다.")
+    @RepeatedTest(10)
+    void generatePath() {
+        final int VALID_LENGTH = 7;
+
+        String generatedPath = generator.generate();
+
+        boolean isInvalidCharacterIncluded = generatedPath.chars()
+                .mapToObj(ch -> (char) ch)
+                .anyMatch(ch -> !pathAvailableCharacters.contains(ch));
+
+        assertThat(generatedPath).hasSize(VALID_LENGTH);
+        assertThat(isInvalidCharacterIncluded).isFalse();
+    }
+
+    private static Set<Character> pathAvailableCharacters() {
+        Set<Character> result = new HashSet<>();
+        for (int ch = 'a'; ch <= 'z'; ch++) {
+            result.add((char) ch);
+        }
+        for (int ch = 'A'; ch <= 'Z'; ch++) {
+            result.add((char) ch);
+        }
+        return result;
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/domain/generator/UuidExpireKeyGeneratorTest.java
+++ b/src/test/java/kr/lnsc/api/link/domain/generator/UuidExpireKeyGeneratorTest.java
@@ -1,0 +1,19 @@
+package kr.lnsc.api.link.domain.generator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UuidExpireKeyGeneratorTest {
+    private ExpireKeyGenerator generator = new UuidExpireKeyGenerator();
+
+    @DisplayName("8자리의 랜덤한 만료키를 생성한다.")
+    @Test
+    void generateExpireKey() {
+        final int EXPIRE_KEY_LENGTH = 8;
+        String expireKey = generator.generate();
+
+        assertThat(expireKey).hasSize(EXPIRE_KEY_LENGTH);
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
@@ -37,7 +37,7 @@ class LinkCommandTest extends ServiceTest {
         assertThat(findLink.getId()).isEqualTo(createdLink.getId());
         assertThat(findLink.getOriginalUrl()).isEqualTo(ORIGINAL_URL);
         assertThat(findLink.getShortenPath()).isNotNull();
-        assertThat(findLink.getExpiredKey()).isNotNull();
+        assertThat(findLink.getExpireKey()).isNotNull();
         assertThat(findLink.getCreatedAt()).isAfter(NOW);
     }
 

--- a/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
@@ -4,6 +4,7 @@ import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
 import kr.lnsc.api.link.exception.CanNotFoundUniquePathException;
 import kr.lnsc.api.link.repository.LinkRepository;
+import kr.lnsc.api.util.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
@@ -7,7 +7,6 @@ import kr.lnsc.api.link.exception.CanNotFoundUniquePathException;
 import kr.lnsc.api.link.exception.InvalidExpireKeyException;
 import kr.lnsc.api.link.repository.LinkRepository;
 import kr.lnsc.api.linkhistory.domain.LinkHistory;
-import kr.lnsc.api.linkhistory.repository.LinkHistoryRepository;
 import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
 import kr.lnsc.api.util.ServiceTest;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
@@ -1,7 +1,6 @@
 package kr.lnsc.api.link.service;
 
 import kr.lnsc.api.link.domain.Link;
-import kr.lnsc.api.link.domain.Url;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
 import kr.lnsc.api.link.exception.CanNotFoundUniquePathException;
 import kr.lnsc.api.link.repository.LinkRepository;
@@ -10,12 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_NEXT_DAY_EXPIRED;
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LinkCommandTest extends ServiceTest {
-    private static final Url ORIGINAL_URL = new Url("http://www.example.com");
 
     @Autowired
     private LinkCommand linkCommand;
@@ -26,19 +27,20 @@ class LinkCommandTest extends ServiceTest {
     @DisplayName("요청한 정보로 Link 객체를 생성한다.")
     @Test
     void createLink() {
-        final LocalDateTime NEXT_DAY = NOW.plusDays(1);
-
-        CreateShortenLinkRequest request = new CreateShortenLinkRequest(ORIGINAL_URL, NEXT_DAY.toLocalDate());
+        CreateShortenLinkRequest request =
+                new CreateShortenLinkRequest(EXAMPLE_NEXT_DAY_EXPIRED.originalUrl, EXAMPLE_NEXT_DAY_EXPIRED.expireDate);
         Link createdLink = linkCommand.createLink(request);
 
         Link findLink = linkRepository.findAll().get(0);
 
+        final LocalDateTime TODAY = LocalDateTime.of(EXAMPLE_TODAY_EXPIRED.expireDate, LocalTime.MAX);
+
         assertThat(linkRepository.findAll()).hasSize(1);
         assertThat(findLink.getId()).isEqualTo(createdLink.getId());
-        assertThat(findLink.getOriginalUrl()).isEqualTo(ORIGINAL_URL);
+        assertThat(findLink.getOriginalUrl()).isEqualTo(EXAMPLE_NEXT_DAY_EXPIRED.originalUrl);
         assertThat(findLink.getShortenPath()).isNotNull();
         assertThat(findLink.getExpireKey()).isNotNull();
-        assertThat(findLink.getCreatedAt()).isAfter(NOW);
+        assertThat(findLink.getExpiredAt()).isAfter(TODAY);
     }
 
     @DisplayName("일정 시도 횟수로도 고유한 단축 Path를 얻지 못하면 예외가 발생한다.")
@@ -49,7 +51,8 @@ class LinkCommandTest extends ServiceTest {
                 () -> "AAAAAAA",
                 () -> "12345678"
         );
-        CreateShortenLinkRequest request = new CreateShortenLinkRequest(ORIGINAL_URL, NOW.toLocalDate());
+        CreateShortenLinkRequest request =
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
 
         customLinkCommand.createLink(request);
 

--- a/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
@@ -1,0 +1,59 @@
+package kr.lnsc.api.link.service;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.link.domain.Url;
+import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.exception.CanNotFoundUniquePathException;
+import kr.lnsc.api.link.repository.LinkRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LinkCommandTest extends ServiceTest {
+    private static final Url ORIGINAL_URL = new Url("http://www.example.com");
+
+    @Autowired
+    private LinkCommand linkCommand;
+
+    @Autowired
+    private LinkRepository linkRepository;
+
+    @DisplayName("요청한 정보로 Link 객체를 생성한다.")
+    @Test
+    void createLink() {
+        final LocalDateTime NEXT_DAY = NOW.plusDays(1);
+
+        CreateShortenLinkRequest request = new CreateShortenLinkRequest(ORIGINAL_URL, NEXT_DAY.toLocalDate());
+        Link createdLink = linkCommand.createLink(request);
+
+        Link findLink = linkRepository.findAll().get(0);
+
+        assertThat(linkRepository.findAll()).hasSize(1);
+        assertThat(findLink.getId()).isEqualTo(createdLink.getId());
+        assertThat(findLink.getOriginalUrl()).isEqualTo(ORIGINAL_URL);
+        assertThat(findLink.getShortenPath()).isNotNull();
+        assertThat(findLink.getExpiredKey()).isNotNull();
+        assertThat(findLink.getCreatedAt()).isAfter(NOW);
+    }
+
+    @DisplayName("일정 시도 횟수로도 고유한 단축 Path를 얻지 못하면 예외가 발생한다.")
+    @Test
+    void uniqueShortenPathFail() {
+        LinkCommand customLinkCommand = new LinkCommand(
+                linkRepository,
+                () -> "AAAAAAA",
+                () -> "12345678"
+        );
+        CreateShortenLinkRequest request = new CreateShortenLinkRequest(ORIGINAL_URL, NOW.toLocalDate());
+
+        customLinkCommand.createLink(request);
+
+        assertThatThrownBy(() -> customLinkCommand.createLink(request))
+                .isInstanceOf(CanNotFoundUniquePathException.class);
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
@@ -2,8 +2,13 @@ package kr.lnsc.api.link.service;
 
 import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.dto.request.CreateShortenLinkRequest;
+import kr.lnsc.api.link.dto.request.ExpireShortenLinkRequest;
 import kr.lnsc.api.link.exception.CanNotFoundUniquePathException;
+import kr.lnsc.api.link.exception.InvalidExpireKeyException;
 import kr.lnsc.api.link.repository.LinkRepository;
+import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import kr.lnsc.api.linkhistory.repository.LinkHistoryRepository;
+import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
 import kr.lnsc.api.util.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +29,12 @@ class LinkCommandTest extends ServiceTest {
 
     @Autowired
     private LinkRepository linkRepository;
+
+    @Autowired
+    private LinkQuery linkQuery;
+
+    @Autowired
+    private LinkHistoryCommand linkHistoryCommand;
 
     @DisplayName("요청한 정보로 Link 객체를 생성한다.")
     @Test
@@ -50,7 +61,9 @@ class LinkCommandTest extends ServiceTest {
         LinkCommand customLinkCommand = new LinkCommand(
                 linkRepository,
                 () -> "AAAAAAA",
-                () -> "12345678"
+                () -> "12345678",
+                linkQuery,
+                linkHistoryCommand
         );
         CreateShortenLinkRequest request =
                 new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
@@ -59,5 +72,36 @@ class LinkCommandTest extends ServiceTest {
 
         assertThatThrownBy(() -> customLinkCommand.createLink(request))
                 .isInstanceOf(CanNotFoundUniquePathException.class);
+    }
+
+    @DisplayName("Link 객체의 만료키와 입력한 만료키가 같을 경우 Link 객체와 LinkHistory 객체를 삭제한다.")
+    @Test
+    void expireLinkSuccess() {
+        Link link = EXAMPLE_NEXT_DAY_EXPIRED.toLink();
+        linkRepository.save(link);
+        linkHistoryRepository.save(LinkHistory.from(link));
+
+        ExpireShortenLinkRequest request =
+                new ExpireShortenLinkRequest(EXAMPLE_NEXT_DAY_EXPIRED.shortenPath, EXAMPLE_NEXT_DAY_EXPIRED.expireKey);
+
+        linkCommand.expireLink(request);
+
+        assertThat(linkRepository.findAll()).hasSize(0);
+        assertThat(linkHistoryRepository.findAll()).hasSize(0);
+    }
+
+    @DisplayName("Link 객체의 만료키와 입력한 만료키가 다른 경우 예외가 발생한다.")
+    @Test
+    void unmatchedExpireKeyFail() {
+        final String INVALID_EXPIRE_KEY = EXAMPLE_TODAY_EXPIRED.expireKey;
+
+        Link link = EXAMPLE_NEXT_DAY_EXPIRED.toLink();
+        linkRepository.save(link);
+
+        ExpireShortenLinkRequest request =
+                new ExpireShortenLinkRequest(EXAMPLE_NEXT_DAY_EXPIRED.shortenPath, INVALID_EXPIRE_KEY);
+
+        assertThatThrownBy(() -> linkCommand.expireLink(request))
+                .isInstanceOf(InvalidExpireKeyException.class);
     }
 }

--- a/src/test/java/kr/lnsc/api/link/service/LinkQueryTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkQueryTest.java
@@ -1,10 +1,13 @@
 package kr.lnsc.api.link.service;
 
+import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.exception.LinkNotFoundException;
+import kr.lnsc.api.util.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_ALREADY_EXPIRED;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LinkQueryTest extends ServiceTest {
@@ -18,6 +21,16 @@ class LinkQueryTest extends ServiceTest {
         final String INVALID_SHORTEN_PATH = "aaaaaaa";
 
         assertThatThrownBy(() -> linkQuery.getLink(INVALID_SHORTEN_PATH))
+                .isInstanceOf(LinkNotFoundException.class);
+    }
+
+    @DisplayName("단축 Path에 해당하는 Link가 만료일이 요청 시점보다 이전일때 예외를 발생시킨다.")
+    @Test
+    void expiredLinkFindFail() {
+        final Link expiredLink = EXAMPLE_ALREADY_EXPIRED.toLink();
+        linkRepository.save(expiredLink);
+
+        assertThatThrownBy(() -> linkQuery.getLink(EXAMPLE_ALREADY_EXPIRED.shortenPath))
                 .isInstanceOf(LinkNotFoundException.class);
     }
 }

--- a/src/test/java/kr/lnsc/api/link/service/LinkQueryTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkQueryTest.java
@@ -1,0 +1,23 @@
+package kr.lnsc.api.link.service;
+
+import kr.lnsc.api.link.exception.LinkNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LinkQueryTest extends ServiceTest {
+
+    @Autowired
+    private LinkQuery linkQuery;
+
+    @DisplayName("단축 Path에 해당하는 Link가 없을때 예외를 발생시킨다.")
+    @Test
+    void notExistLinkFindFail() {
+        final String INVALID_SHORTEN_PATH = "aaaaaaa";
+
+        assertThatThrownBy(() -> linkQuery.getLink(INVALID_SHORTEN_PATH))
+                .isInstanceOf(LinkNotFoundException.class);
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/service/ServiceTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/ServiceTest.java
@@ -1,0 +1,24 @@
+package kr.lnsc.api.link.service;
+
+import kr.lnsc.api.config.JpaConfig;
+import kr.lnsc.api.link.repository.LinkRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+
+@SpringBootTest
+@Import(JpaConfig.class)
+public class ServiceTest {
+    protected static final LocalDateTime NOW = LocalDateTime.now();
+
+    @Autowired
+    private LinkRepository linkRepository;
+
+    @AfterEach
+    void clear() {
+        linkRepository.deleteAll();
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/service/ServiceTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/ServiceTest.java
@@ -7,12 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
-import java.time.LocalDateTime;
-
 @SpringBootTest
 @Import(JpaConfig.class)
 public class ServiceTest {
-    protected static final LocalDateTime NOW = LocalDateTime.now();
 
     @Autowired
     private LinkRepository linkRepository;

--- a/src/test/java/kr/lnsc/api/link/validator/ExpireTimeValidatorTest.java
+++ b/src/test/java/kr/lnsc/api/link/validator/ExpireTimeValidatorTest.java
@@ -14,6 +14,18 @@ import static org.mockito.Mockito.mock;
 class ExpireTimeValidatorTest {
     private ExpireTimeValidator expireTimeValidator = new ExpireTimeValidator();
 
+    @DisplayName("입력한 만료일자가 null인 경우 유효성 검사에 실패한다.")
+    @Test
+    void expireDateIsNullFail() {
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+        given(context.buildConstraintViolationWithTemplate(anyString()))
+                .willReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
+
+        boolean isValid = expireTimeValidator.isValid(null, context);
+
+        assertThat(isValid).isFalse();
+    }
+
     @DisplayName("입력한 만료일자가 오늘보다 이전 날일 경우 유효성 검사에 실패한다.")
     @Test
     void expireDateIsAfterFail() {

--- a/src/test/java/kr/lnsc/api/link/validator/ExpireTimeValidatorTest.java
+++ b/src/test/java/kr/lnsc/api/link/validator/ExpireTimeValidatorTest.java
@@ -1,0 +1,44 @@
+package kr.lnsc.api.link.validator;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class ExpireTimeValidatorTest {
+    private ExpireTimeValidator expireTimeValidator = new ExpireTimeValidator();
+
+    @DisplayName("입력한 만료일자가 오늘보다 이전 날일 경우 유효성 검사에 실패한다.")
+    @Test
+    void expireDateIsAfterFail() {
+        final LocalDate YESTERDAY = LocalDate.now().minusDays(1);
+
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+        given(context.buildConstraintViolationWithTemplate(anyString()))
+                .willReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
+
+        boolean isValid = expireTimeValidator.isValid(YESTERDAY, context);
+
+        assertThat(isValid).isFalse();
+    }
+
+    @DisplayName("입력한 만료일자가 오늘 포함 이후 날일 경우 유효성 검사에 성공한다.")
+    @Test
+    void expireDateSuccess() {
+        final LocalDate TODAY = LocalDate.now();
+
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+        given(context.buildConstraintViolationWithTemplate(anyString()))
+                .willReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
+
+        boolean isValid = expireTimeValidator.isValid(TODAY, context);
+
+        assertThat(isValid).isTrue();
+    }
+}

--- a/src/test/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommandTest.java
+++ b/src/test/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommandTest.java
@@ -1,0 +1,41 @@
+package kr.lnsc.api.linkhistory.service;
+
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import kr.lnsc.api.util.ServiceTest;
+import org.assertj.core.api.Fail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LinkHistoryCommandTest extends ServiceTest {
+
+    @Autowired
+    private LinkHistoryCommand linkHistoryCommand;
+
+    @DisplayName("Link로 LinkHistory 객체를 생성한다.")
+    @Test
+    void createHistorySuccess() {
+        Link link = linkRepository.save(EXAMPLE_TODAY_EXPIRED.toLink());
+        LinkHistory createdLinkHistory = linkHistoryCommand.createHistory(link);
+
+        LinkHistory findLinkHistory = linkHistoryRepository.findById(createdLinkHistory.getId())
+                .orElseGet(() -> Fail.fail("해당 LinkHistory가 존재하지 않습니다."));
+        assertThat(findLinkHistory.getId()).isEqualTo(createdLinkHistory.getId());
+        assertThat(findLinkHistory.getLink().getId()).isEqualTo(link.getId());
+    }
+
+    @DisplayName("단축 Path로 Link를 찾은 후 LinkHistory를 생성하고, 해당 Link를 반환한다.")
+    @Test
+    void accessLinkSuccess() {
+        Link link = linkRepository.save(EXAMPLE_TODAY_EXPIRED.toLink());
+        Link accessLink = linkHistoryCommand.accessLink(EXAMPLE_TODAY_EXPIRED.shortenPath);
+
+        LinkHistory createdLinkHistory = linkHistoryRepository.findAll().get(0);
+        assertThat(link.getId()).isEqualTo(accessLink.getId());
+        assertThat(createdLinkHistory.getLink().getId()).isEqualTo(link.getId());
+    }
+}

--- a/src/test/java/kr/lnsc/api/linkhistory/service/LinkHistoryQueryTest.java
+++ b/src/test/java/kr/lnsc/api/linkhistory/service/LinkHistoryQueryTest.java
@@ -1,0 +1,76 @@
+package kr.lnsc.api.linkhistory.service;
+
+import kr.lnsc.api.fixture.LinkHistoryFixture;
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import kr.lnsc.api.linkhistory.dto.LinkAccessCountDto;
+import kr.lnsc.api.util.ServiceTest;
+import kr.lnsc.api.util.TestLinkHistoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static kr.lnsc.api.fixture.LinkFixture.EXAMPLE_TODAY_EXPIRED;
+import static kr.lnsc.api.fixture.LinkHistoryFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(TestLinkHistoryRepository.class)
+class LinkHistoryQueryTest extends ServiceTest {
+    private static Link link;
+
+    @Autowired
+    private LinkHistoryQuery linkHistoryQuery;
+
+    @Autowired
+    private TestLinkHistoryRepository testLinkHistoryRepository;
+
+    @BeforeEach
+    void setUp() {
+        link = EXAMPLE_TODAY_EXPIRED.toLink();
+        linkRepository.save(link);
+
+        Arrays.stream(LinkHistoryFixture.values())
+                .forEach(lhf -> {
+                    LinkHistory savedLinkHistory = linkHistoryRepository.save(lhf.toLinkHistory(link));
+                    testLinkHistoryRepository.updateAccessedAt(savedLinkHistory, lhf.accessedAt);
+                });
+    }
+
+    @DisplayName("단축 URL 접속 횟수를 특정 일자 기준으로 묶어 오름차순으로 반환한다.")
+    @Test
+    void getAccessCountByDate() {
+        List<LinkAccessCountDto> accessCountByDate = linkHistoryQuery.getAccessCountByDate(link);
+
+        List<LocalDate> expectedAccessedDate = Stream.of(ACCESS_LAST_WEEK, ACCESS_YESTERDAY, ACCESS_TODAY)
+                .map(lhf -> lhf.accessedAt)
+                .map(LocalDateTime::toLocalDate)
+                .toList();
+        assertThat(accessCountByDate).hasSize(3);
+        assertThat(accessCountByDate).extracting("date").containsExactlyElementsOf(expectedAccessedDate);
+        assertThat(accessCountByDate).extracting("count").containsOnly(1L);
+    }
+
+    @DisplayName("특정 일자의 단축 URL 접속 횟수를 반환한다.")
+    @Test
+    void getSpecificDateAccessCount() {
+        long todayAccessCount = linkHistoryQuery.getAccessCount(link, LocalDate.now());
+
+        assertThat(todayAccessCount).isEqualTo(1L);
+    }
+
+    @DisplayName("단축 URL의 전체 접속 횟수를 반환한다.")
+    @Test
+    void getTotalAccessCount() {
+        long totalAccessCount = linkHistoryQuery.getTotalAccessCount(link);
+
+        assertThat(totalAccessCount).isEqualTo(3L);
+    }
+}

--- a/src/test/java/kr/lnsc/api/util/AcceptanceTest.java
+++ b/src/test/java/kr/lnsc/api/util/AcceptanceTest.java
@@ -1,0 +1,31 @@
+package kr.lnsc.api.util;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({DatabaseInitializer.class, TestLinkHistoryRepository.class})
+public class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private DatabaseInitializer databaseInitializer;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        databaseInitializer.setUp();
+    }
+
+    @AfterEach
+    void clear() {
+        databaseInitializer.clear();
+    }
+}

--- a/src/test/java/kr/lnsc/api/util/ControllerTest.java
+++ b/src/test/java/kr/lnsc/api/util/ControllerTest.java
@@ -3,9 +3,15 @@ package kr.lnsc.api.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import kr.lnsc.api.link.controller.LinkController;
+import kr.lnsc.api.link.controller.LinkRestController;
+import kr.lnsc.api.link.service.LinkCommand;
+import kr.lnsc.api.link.service.LinkQuery;
+import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
+import kr.lnsc.api.linkhistory.service.LinkHistoryQuery;
 import kr.lnsc.api.property.BaseUrlProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -14,9 +20,22 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
-@WebMvcTest(LinkController.class)
+@WebMvcTest(controllers = {LinkRestController.class, LinkController.class})
 @Import(BaseUrlProperty.class)
 public class ControllerTest {
+
+    @MockBean
+    protected LinkCommand linkCommand;
+
+    @MockBean
+    protected LinkQuery linkQuery;
+
+    @MockBean
+    protected LinkHistoryQuery linkHistoryQuery;
+
+    @MockBean
+    protected LinkHistoryCommand linkHistoryCommand;
+
     protected MockMvc mockMvc;
 
     protected ObjectMapper objectMapper;

--- a/src/test/java/kr/lnsc/api/util/ControllerTest.java
+++ b/src/test/java/kr/lnsc/api/util/ControllerTest.java
@@ -1,7 +1,8 @@
-package kr.lnsc.api.link.controller;
+package kr.lnsc.api.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import kr.lnsc.api.link.controller.LinkController;
 import kr.lnsc.api.property.BaseUrlProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;

--- a/src/test/java/kr/lnsc/api/util/DatabaseInitializer.java
+++ b/src/test/java/kr/lnsc/api/util/DatabaseInitializer.java
@@ -1,0 +1,84 @@
+package kr.lnsc.api.util;
+
+import com.google.common.base.CaseFormat;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.metamodel.EntityType;
+import kr.lnsc.api.link.domain.Link;
+import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static kr.lnsc.api.fixture.LinkFixture.*;
+import static kr.lnsc.api.fixture.LinkHistoryFixture.ACCESS_LAST_WEEK;
+import static kr.lnsc.api.fixture.LinkHistoryFixture.ACCESS_TODAY;
+
+@TestComponent
+public class DatabaseInitializer implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private TestLinkHistoryRepository testLinkHistoryRepository;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        this.tableNames = entityManager.getMetamodel()
+                .getEntities().stream()
+                .map(EntityType::getJavaType)
+                .filter(entityType -> entityType.isAnnotationPresent(Entity.class))
+                .map(Class::getSimpleName)
+                .map(this::toSnakeCase)
+                .toList();
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = FALSE").executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " AUTO_INCREMENT = 1")
+                    .executeUpdate();
+        }
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = TRUE").executeUpdate();
+    }
+
+    @Transactional
+    public void setUp() {
+        Link alreadyExpiredLink = EXAMPLE_ALREADY_EXPIRED.toLink();
+        Link todayExpiredLink = EXAMPLE_TODAY_EXPIRED.toLink();
+        Link nextDayExpiredLink = EXAMPLE_NEXT_DAY_EXPIRED.toLink();
+        addEntity(alreadyExpiredLink, todayExpiredLink, nextDayExpiredLink);
+
+        LinkHistory alreadyExpiredLinkLastWeekHistory = ACCESS_LAST_WEEK.toLinkHistory(alreadyExpiredLink);
+        LinkHistory todayExpiredLinkLastWeekHistory = ACCESS_LAST_WEEK.toLinkHistory(todayExpiredLink);
+        LinkHistory nextdayExpiredLinkTodayHistory = ACCESS_TODAY.toLinkHistory(nextDayExpiredLink);
+        addEntity(alreadyExpiredLinkLastWeekHistory,
+                todayExpiredLinkLastWeekHistory,
+                nextdayExpiredLinkTodayHistory);
+
+        testLinkHistoryRepository.updateAccessedAt(alreadyExpiredLinkLastWeekHistory, ACCESS_LAST_WEEK.accessedAt);
+        testLinkHistoryRepository.updateAccessedAt(todayExpiredLinkLastWeekHistory, ACCESS_LAST_WEEK.accessedAt);
+        testLinkHistoryRepository.updateAccessedAt(nextdayExpiredLinkTodayHistory, ACCESS_TODAY.accessedAt);
+    }
+
+    private <T> void addEntity(T... entities) {
+        Arrays.asList(entities).forEach(entityManager::persist);
+        entityManager.flush();
+    }
+
+    private String toSnakeCase(String camelCaseString) {
+        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, camelCaseString);
+    }
+}

--- a/src/test/java/kr/lnsc/api/util/ServiceTest.java
+++ b/src/test/java/kr/lnsc/api/util/ServiceTest.java
@@ -1,4 +1,4 @@
-package kr.lnsc.api.link.service;
+package kr.lnsc.api.util;
 
 import kr.lnsc.api.config.JpaConfig;
 import kr.lnsc.api.link.repository.LinkRepository;
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Import;
 public class ServiceTest {
 
     @Autowired
-    private LinkRepository linkRepository;
+    protected LinkRepository linkRepository;
 
     @AfterEach
     void clear() {

--- a/src/test/java/kr/lnsc/api/util/ServiceTest.java
+++ b/src/test/java/kr/lnsc/api/util/ServiceTest.java
@@ -2,6 +2,7 @@ package kr.lnsc.api.util;
 
 import kr.lnsc.api.config.JpaConfig;
 import kr.lnsc.api.link.repository.LinkRepository;
+import kr.lnsc.api.linkhistory.repository.LinkHistoryRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,8 +15,12 @@ public class ServiceTest {
     @Autowired
     protected LinkRepository linkRepository;
 
+    @Autowired
+    protected LinkHistoryRepository linkHistoryRepository;
+
     @AfterEach
     void clear() {
+        linkHistoryRepository.deleteAll();
         linkRepository.deleteAll();
     }
 }

--- a/src/test/java/kr/lnsc/api/util/TestLinkHistoryRepository.java
+++ b/src/test/java/kr/lnsc/api/util/TestLinkHistoryRepository.java
@@ -1,0 +1,24 @@
+package kr.lnsc.api.util;
+
+import jakarta.persistence.EntityManager;
+import kr.lnsc.api.linkhistory.domain.LinkHistory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@TestComponent
+public class TestLinkHistoryRepository {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Transactional
+    public void updateAccessedAt(LinkHistory savedLinkHistory, LocalDateTime accessedAt) {
+        entityManager.createQuery("update LinkHistory lh set lh.createdAt = :accessedAt where lh = :savedLinkHistory")
+                .setParameter("accessedAt", accessedAt)
+                .setParameter("savedLinkHistory", savedLinkHistory)
+                .executeUpdate();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,13 +1,14 @@
 spring:
   jpa:
-    open-in-view: false
+    show-sql: false
     hibernate:
       ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: false
 
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb
-    username: sa
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8:///test
 
-env:
-  base-url: https://www.test.kr
+base-url: https://www.test.kr

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+
+env:
+  base-url: https://www.test.kr

--- a/src/test/resources/spy.properties
+++ b/src/test/resources/spy.properties
@@ -1,0 +1,1 @@
+appender=com.p6spy.engine.spy.appender.Slf4JLogger


### PR DESCRIPTION
[기능 요구사항](https://www.notion.so/b22b39ec90694a31aecfcd4f93197b04?pvs=4)에서 기술한 URL 단축 기능 구현

URL 단축 - 원래 URL과 만료일 입력시 단축 URL 생성
단축 URL 접속 - 유효한 단축 URL로 접속시 원래 URL로 리다이렉트
단축 URL 만료 - 유효한 단축 URL에 대해 단축 URL 생성시 발급된 만료키를 입력해 해당 단축 URL을 임의로 만료
단축 URL 정보 조회 - 유효한 단축 URL에 대한 정보들을 조회 (원래 URL, 하루 접속수, 누적 접속수, 생성일, 만료일)

구현 클래스에 대한 단위 테스트 완료