### PR TITLE
단축 URL 생성시 잘못된 형식의 URL 입력시 500 에러 발생 문제 해결

### DIFF
--- a/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
+++ b/src/main/java/kr/lnsc/api/link/dto/request/CreateShortenLinkRequest.java
@@ -2,33 +2,28 @@ package kr.lnsc.api.link.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import kr.lnsc.api.link.domain.Url;
 import kr.lnsc.api.link.validator.ExpireTime;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
 
 import java.time.LocalDate;
 
+@Getter
 @NoArgsConstructor
 public class CreateShortenLinkRequest {
 
     @Schema(description = "단축할 원본 URL")
     @NotNull(message = "단축할 URL 주소를 입력해주세요.")
-    private Url originalUrl;
+    @URL(message = "잘못된 URL 형식입니다. 확인 후 다시 입력해주세요.")
+    private String originalUrl;
 
     @Schema(description = "단축 URL 만료일자")
     @ExpireTime
     private LocalDate expireDate;
 
-    public CreateShortenLinkRequest(Url originalUrl, LocalDate expireDate) {
+    public CreateShortenLinkRequest(String originalUrl, LocalDate expireDate) {
         this.originalUrl = originalUrl;
         this.expireDate = expireDate;
-    }
-
-    public String getOriginalUrl() {
-        return originalUrl.getValue();
-    }
-
-    public LocalDate getExpireDate() {
-        return expireDate;
     }
 }

--- a/src/test/java/kr/lnsc/api/link/acceptance/LinkAcceptanceTest.java
+++ b/src/test/java/kr/lnsc/api/link/acceptance/LinkAcceptanceTest.java
@@ -27,7 +27,7 @@ public class LinkAcceptanceTest extends AcceptanceTest {
     @Test
     void createLink() {
         CreateShortenLinkRequest request =
-                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl.getValue(), EXAMPLE_TODAY_EXPIRED.expireDate);
 
         ExtractableResponse<Response> response = httpPost(request, "/api/link/create");
         CreateShortenLinkResponse responseDto = response.body().as(CreateShortenLinkResponse.class);
@@ -42,7 +42,7 @@ public class LinkAcceptanceTest extends AcceptanceTest {
     @Test
     void createLinkWithSameOriginalURL() {
         CreateShortenLinkRequest request =
-                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl.getValue(), EXAMPLE_TODAY_EXPIRED.expireDate);
 
         ExtractableResponse<Response> firstResponse = httpPost(request, "/api/link/create");
         assertThat(firstResponse.statusCode()).isEqualTo(HttpStatus.OK.value());

--- a/src/test/java/kr/lnsc/api/link/controller/LinkRestControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkRestControllerTest.java
@@ -31,7 +31,7 @@ class LinkRestControllerTest extends ControllerTest {
     @Test
     void createShortenLink() throws Exception {
         CreateShortenLinkRequest request =
-                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl.getValue(), EXAMPLE_TODAY_EXPIRED.expireDate);
 
         given(linkCommand.createLink(any(CreateShortenLinkRequest.class)))
                 .willReturn(EXAMPLE_TODAY_EXPIRED.toLink());

--- a/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
@@ -39,7 +39,7 @@ class LinkCommandTest extends ServiceTest {
     @Test
     void createLink() {
         CreateShortenLinkRequest request =
-                new CreateShortenLinkRequest(EXAMPLE_NEXT_DAY_EXPIRED.originalUrl, EXAMPLE_NEXT_DAY_EXPIRED.expireDate);
+                new CreateShortenLinkRequest(EXAMPLE_NEXT_DAY_EXPIRED.originalUrl.getValue(), EXAMPLE_NEXT_DAY_EXPIRED.expireDate);
         Link createdLink = linkCommand.createLink(request);
 
         Link findLink = linkRepository.findAll().get(0);
@@ -65,7 +65,7 @@ class LinkCommandTest extends ServiceTest {
                 linkHistoryCommand
         );
         CreateShortenLinkRequest request =
-                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl, EXAMPLE_TODAY_EXPIRED.expireDate);
+                new CreateShortenLinkRequest(EXAMPLE_TODAY_EXPIRED.originalUrl.getValue(), EXAMPLE_TODAY_EXPIRED.expireDate);
 
         customLinkCommand.createLink(request);
 


### PR DESCRIPTION
이전 PR에서 병합 branch 잘못 설정으로 다시 PR함.