### PR TITLE
스프링 서버 시간과 DB에 저장되는 시간이 달라 생기는 문제를 해결

### DIFF
--- a/src/main/java/kr/lnsc/api/config/TimeConfig.java
+++ b/src/main/java/kr/lnsc/api/config/TimeConfig.java
@@ -1,0 +1,16 @@
+package kr.lnsc.api.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+public class TimeConfig {
+    private static final String ZONE = "Asia/Seoul";
+
+    @PostConstruct
+    void initTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZONE));
+    }
+}


### PR DESCRIPTION
서버의 TimeZone을 Asia/Seoul로 변경해 문제를 해결