### PR TITLE
캐시 및 비동기 적용으로 서버 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,11 @@ dependencies {
 
     implementation 'com.google.guava:guava:32.1.2-jre'
 
+    // Memcached Cache
+    implementation 'com.google.code.simple-spring-memcached:spring-cache:4.1.3'
+    implementation 'com.google.code.simple-spring-memcached:simple-spring-memcached:4.1.3'
+    implementation 'com.google.code.simple-spring-memcached:xmemcached-provider:4.1.3'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
 

--- a/src/main/java/kr/lnsc/api/config/AsyncConfig.java
+++ b/src/main/java/kr/lnsc/api/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package kr.lnsc.api.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+}

--- a/src/main/java/kr/lnsc/api/config/CacheConfig.java
+++ b/src/main/java/kr/lnsc/api/config/CacheConfig.java
@@ -1,0 +1,67 @@
+package kr.lnsc.api.config;
+
+import com.google.code.ssm.Cache;
+import com.google.code.ssm.CacheFactory;
+import com.google.code.ssm.config.AddressProvider;
+import com.google.code.ssm.config.DefaultAddressProvider;
+import com.google.code.ssm.providers.CacheConfiguration;
+import com.google.code.ssm.providers.xmemcached.MemcacheClientFactoryImpl;
+import com.google.code.ssm.spring.ExtendedSSMCacheManager;
+import com.google.code.ssm.spring.SSMCache;
+import com.google.code.ssm.spring.SSMCacheManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@EnableCaching
+@EnableAspectJAutoProxy
+public class CacheConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "spring.cache.type", havingValue = "memcached")
+    public CacheManager cacheManager(@Value("${cache.address:localhost:11211}") String address,
+                                     @Value("${cache.operationTimeout:500}") int operationTimeout,
+                                     @Value("${cache.cacheName:link}") String cacheName,
+                                     @Value("${cache.expiration:1800}") int expiration) {
+        CacheConfiguration cacheConfiguration = new CacheConfiguration();
+        cacheConfiguration.setConsistentHashing(true);
+        cacheConfiguration.setUseBinaryProtocol(true);
+        cacheConfiguration.setOperationTimeout(operationTimeout);
+        cacheConfiguration.setUseNameAsKeyPrefix(true);
+        cacheConfiguration.setKeyPrefixSeparator(":");
+
+        MemcacheClientFactoryImpl cacheClientFactory = new MemcacheClientFactoryImpl();
+        AddressProvider addressProvider = new DefaultAddressProvider(address);
+
+        CacheFactory cacheFactory = new CacheFactory();
+        cacheFactory.setCacheName(cacheName);
+        cacheFactory.setCacheClientFactory(cacheClientFactory);
+        cacheFactory.setAddressProvider(addressProvider);
+        cacheFactory.setConfiguration(cacheConfiguration);
+
+        Cache cache;
+        try {
+            cache = cacheFactory.getObject();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        SSMCache ssmCache = new SSMCache(cache, expiration, true);
+
+        List<SSMCache> ssmCaches = new ArrayList<>();
+        ssmCaches.add(ssmCache);
+
+        SSMCacheManager ssmCacheManager = new ExtendedSSMCacheManager();
+        ssmCacheManager.setCaches(ssmCaches);
+
+        return ssmCacheManager;
+    }
+}

--- a/src/main/java/kr/lnsc/api/link/controller/LinkController.java
+++ b/src/main/java/kr/lnsc/api/link/controller/LinkController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.lnsc.api.link.domain.Link;
-import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
+import kr.lnsc.api.link.service.LinkCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,14 +15,14 @@ import org.springframework.web.servlet.view.RedirectView;
 @Controller
 @RequiredArgsConstructor
 public class LinkController {
-    private final LinkHistoryCommand linkHistoryCommand;
+    private final LinkCommand linkCommand;
 
     @Operation(summary = "단축 URL 접속", description = "단축 URL로 접속하면 원래 URL로 리다이렉트됩니다.")
     @GetMapping("/{shortenPath}")
     public RedirectView redirectToOriginalUrl(
             @Parameter(description = "단축 URL Path") @PathVariable String shortenPath
     ) {
-        Link findLink = linkHistoryCommand.accessLink(shortenPath);
+        Link findLink = linkCommand.accessLink(shortenPath);
         return new RedirectView(findLink.getOriginalUrl().getValue());
     }
 }

--- a/src/main/java/kr/lnsc/api/link/domain/Link.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Link.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,7 +16,7 @@ import java.time.LocalTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Link extends TimeBaseEntity {
+public class Link extends TimeBaseEntity implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/lnsc/api/link/domain/Url.java
+++ b/src/main/java/kr/lnsc/api/link/domain/Url.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
 
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -20,7 +21,7 @@ import java.util.regex.Pattern;
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Url {
+public class Url implements Serializable {
     public static final int URL_MAX_LENGTH = 2048;
     private static final Pattern PATTERN = Pattern.compile("https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#()?&//=]*)");
 

--- a/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
+++ b/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
@@ -52,6 +52,12 @@ public class LinkCommand {
         linkRepository.deleteById(findLink.getId());
     }
 
+    public Link accessLink(String shortenPath) {
+        Link findLink = linkQuery.getLink(shortenPath);
+        linkHistoryCommand.createHistoryAsync(findLink);
+        return findLink;
+    }
+
     private String getUniqueShortenPath() {
         int attempt = 0;
         while (attempt < ATTEMPT_LIMIT) {

--- a/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
+++ b/src/main/java/kr/lnsc/api/link/service/LinkCommand.java
@@ -11,6 +11,7 @@ import kr.lnsc.api.link.exception.InvalidExpireKeyException;
 import kr.lnsc.api.link.repository.LinkRepository;
 import kr.lnsc.api.linkhistory.service.LinkHistoryCommand;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,7 @@ public class LinkCommand {
         return linkRepository.save(createdLink);
     }
 
+    @CacheEvict(value = "link", key = "#request.shortenPath")
     public void expireLink(ExpireShortenLinkRequest request) {
         Link findLink = linkQuery.getLink(request.getShortenPath());
 

--- a/src/main/java/kr/lnsc/api/link/service/LinkQuery.java
+++ b/src/main/java/kr/lnsc/api/link/service/LinkQuery.java
@@ -4,6 +4,7 @@ import kr.lnsc.api.link.domain.Link;
 import kr.lnsc.api.link.exception.LinkNotFoundException;
 import kr.lnsc.api.link.repository.LinkRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LinkQuery {
     private final LinkRepository linkRepository;
 
+    @Cacheable(value = "link", key = "#shortenPath")
     public Link getLink(String shortenPath) {
         return linkRepository.findLink(shortenPath)
                 .orElseThrow(LinkNotFoundException::new);

--- a/src/main/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommand.java
+++ b/src/main/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommand.java
@@ -1,29 +1,34 @@
 package kr.lnsc.api.linkhistory.service;
 
 import kr.lnsc.api.link.domain.Link;
-import kr.lnsc.api.link.service.LinkQuery;
 import kr.lnsc.api.linkhistory.domain.LinkHistory;
 import kr.lnsc.api.linkhistory.repository.LinkHistoryRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LinkHistoryCommand {
     private final LinkHistoryRepository linkHistoryRepository;
-    private final LinkQuery linkQuery;
 
     public LinkHistory createHistory(Link link) {
         LinkHistory newLinkHistory = LinkHistory.from(link);
         return linkHistoryRepository.save(newLinkHistory);
     }
 
-    public Link accessLink(String shortenPath) {
-        Link findLink = linkQuery.getLink(shortenPath);
-        this.createHistory(findLink);
-        return findLink;
+    @Async
+    public void createHistoryAsync(Link link) {
+        try {
+            this.createHistory(link);
+        } catch (IllegalArgumentException | OptimisticLockingFailureException e) {
+            log.error("Async task saving link history was failed.", e);
+        }
     }
 
     public void removeAllLinkHistory(Link link) {

--- a/src/test/java/kr/lnsc/api/config/AsyncConfig.java
+++ b/src/test/java/kr/lnsc/api/config/AsyncConfig.java
@@ -1,0 +1,16 @@
+package kr.lnsc.api.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.SyncTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@TestConfiguration
+public class AsyncConfig {
+
+    @Bean
+    public Executor executor() {
+        return new SyncTaskExecutor();
+    }
+}

--- a/src/test/java/kr/lnsc/api/config/AsyncConfig.java
+++ b/src/test/java/kr/lnsc/api/config/AsyncConfig.java
@@ -3,10 +3,12 @@ package kr.lnsc.api.config;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.concurrent.Executor;
 
 @TestConfiguration
+@EnableAsync
 public class AsyncConfig {
 
     @Bean

--- a/src/test/java/kr/lnsc/api/config/CacheConfig.java
+++ b/src/test/java/kr/lnsc/api/config/CacheConfig.java
@@ -1,0 +1,15 @@
+package kr.lnsc.api.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new SimpleCacheManager();
+    }
+}

--- a/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
+++ b/src/test/java/kr/lnsc/api/link/controller/LinkControllerTest.java
@@ -18,7 +18,7 @@ public class LinkControllerTest extends ControllerTest {
     @DisplayName("단축 URL로 접속 요쳥시 원래 URL로 리다이렉트한다.")
     @Test
     void accessLink() throws Exception {
-        given(linkHistoryCommand.accessLink(anyString()))
+        given(linkCommand.accessLink(anyString()))
                 .willReturn(EXAMPLE_TODAY_EXPIRED.toLink());
 
         mockMvc.perform(get("/{shortenPath}", EXAMPLE_TODAY_EXPIRED.shortenPath)

--- a/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
+++ b/src/test/java/kr/lnsc/api/link/service/LinkCommandTest.java
@@ -103,4 +103,15 @@ class LinkCommandTest extends ServiceTest {
         assertThatThrownBy(() -> linkCommand.expireLink(request))
                 .isInstanceOf(InvalidExpireKeyException.class);
     }
+
+    @DisplayName("단축 Path로 Link를 찾은 후 LinkHistory를 생성하고, 해당 Link를 반환한다.")
+    @Test
+    void accessLinkSuccess() {
+        Link link = linkRepository.save(EXAMPLE_TODAY_EXPIRED.toLink());
+        Link accessLink = linkCommand.accessLink(EXAMPLE_TODAY_EXPIRED.shortenPath);
+
+        LinkHistory createdLinkHistory = linkHistoryRepository.findAll().get(0);
+        assertThat(link.getId()).isEqualTo(accessLink.getId());
+        assertThat(createdLinkHistory.getLink().getId()).isEqualTo(link.getId());
+    }
 }

--- a/src/test/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommandTest.java
+++ b/src/test/java/kr/lnsc/api/linkhistory/service/LinkHistoryCommandTest.java
@@ -27,15 +27,4 @@ class LinkHistoryCommandTest extends ServiceTest {
         assertThat(findLinkHistory.getId()).isEqualTo(createdLinkHistory.getId());
         assertThat(findLinkHistory.getLink().getId()).isEqualTo(link.getId());
     }
-
-    @DisplayName("단축 Path로 Link를 찾은 후 LinkHistory를 생성하고, 해당 Link를 반환한다.")
-    @Test
-    void accessLinkSuccess() {
-        Link link = linkRepository.save(EXAMPLE_TODAY_EXPIRED.toLink());
-        Link accessLink = linkHistoryCommand.accessLink(EXAMPLE_TODAY_EXPIRED.shortenPath);
-
-        LinkHistory createdLinkHistory = linkHistoryRepository.findAll().get(0);
-        assertThat(link.getId()).isEqualTo(accessLink.getId());
-        assertThat(createdLinkHistory.getLink().getId()).isEqualTo(link.getId());
-    }
 }


### PR DESCRIPTION
- memcached를 이용해 글로벌 캐싱을 Link 조회, 만료에 적용
    - Link 조회시 캐시에 이미 있으면 바로 가져오고, 없으면 DB에서 가져온 후 캐시에 저장
    - Link 만료시 캐시에 값이 있으면 캐시에서 삭제
- 단축 URL에 접속시 DB에 접속 기록 생성하는 부분을 동기에서 비동기로 변경